### PR TITLE
Change host name from cfe_16 to cfe-16

### DIFF
--- a/src/main/java/com/teragrep/cfe_16/Converter.java
+++ b/src/main/java/com/teragrep/cfe_16/Converter.java
@@ -71,6 +71,8 @@ public class Converter {
     private SDElement metadataSDE;
     private SDElement headerSDE;
 
+    private final String hostName = "cfe-16";
+
     public SyslogMessage httpToSyslog(HttpEventData httpEventData, HeaderInfo headerInfo) {
 
         setEventSeverity();
@@ -87,7 +89,7 @@ public class Converter {
              */
             LOGGER.debug("Creating new syslog message with timestamp");
             syslogMessage = new SyslogMessage().withTimestamp(httpEventData.getTimeAsLong()).withSeverity(severity)
-                    .withAppName("capsulated").withHostname("cfe_16").withFacility(facility).withSDElement(metadataSDE)
+                    .withAppName("capsulated").withHostname(hostName).withFacility(facility).withSDElement(metadataSDE)
                     .withSDElement(headerSDE).withMsg(httpEventData.getEvent());
 
         } else {
@@ -96,7 +98,7 @@ public class Converter {
              * in the request.
              */
             LOGGER.debug("Creating new syslog message without timestamp");
-            syslogMessage = new SyslogMessage().withSeverity(severity).withAppName("capsulated").withHostname("cfe_16")
+            syslogMessage = new SyslogMessage().withSeverity(severity).withAppName("capsulated").withHostname(hostName)
                     .withFacility(facility).withSDElement(metadataSDE).withSDElement(headerSDE)
                     .withMsg(httpEventData.getEvent());
         }
@@ -157,7 +159,7 @@ public class Converter {
 
         SyslogMessage syslogMessage = null;
         setHeaderSDE(headerInfo);
-        syslogMessage = new SyslogMessage().withSeverity(severity).withAppName("capsulated").withHostname("cfe_16")
+        syslogMessage = new SyslogMessage().withSeverity(severity).withAppName("capsulated").withHostname(hostName)
                 .withFacility(facility).withSDElement(headerSDE);
 
         return syslogMessage;

--- a/src/test/java/com/teragrep/cfe_16/ConverterTests.java
+++ b/src/test/java/com/teragrep/cfe_16/ConverterTests.java
@@ -152,15 +152,15 @@ public class ConverterTests {
         metadataSDE3.addSDParam("time_source", eventData3.getTimeSource());
 
         supposedSyslogMessage1 = new SyslogMessage().withTimestamp(eventData1.getTimeAsLong())
-                .withSeverity(supposedSeverity).withAppName("capsulated").withHostname("cfe_16")
+                .withSeverity(supposedSeverity).withAppName("capsulated").withHostname("cfe-16")
                 .withFacility(supposedFacility).withSDElement(metadataSDE1).withMsg(eventData1.getEvent());
 
         supposedSyslogMessage2 = new SyslogMessage().withSeverity(supposedSeverity).withAppName("capsulated")
-                .withHostname("cfe_16").withFacility(supposedFacility).withSDElement(metadataSDE2)
+                .withHostname("cfe-16").withFacility(supposedFacility).withSDElement(metadataSDE2)
                 .withMsg(eventData2.getEvent());
 
         supposedSyslogMessage3 = new SyslogMessage().withSeverity(supposedSeverity).withAppName("capsulated")
-                .withHostname("cfe_16").withFacility(supposedFacility).withSDElement(metadataSDE3)
+                .withHostname("cfe-16").withFacility(supposedFacility).withSDElement(metadataSDE3)
                 .withMsg(eventData3.getEvent());
         HeaderInfo headerInfo = new HeaderInfo();
 

--- a/src/test/java/com/teragrep/cfe_16/ConverterTests.java
+++ b/src/test/java/com/teragrep/cfe_16/ConverterTests.java
@@ -205,7 +205,7 @@ public class ConverterTests {
     /*
      * Compares the AppName and HostName from the supposed SyslogMessage and the
      * SyslogMessage returned from Converter. AppName should be hardcoded to
-     * "capsulated" and HostName should be hardcoded to "cfe_16".
+     * "capsulated" and HostName should be hardcoded to "cfe-16".
      */
     @Test
     public void appNameAndHostNameTest() {


### PR DESCRIPTION
Fixes issue #2 

The host name was hard coded into the syslog messages as cfe_16. I changed it to the more accurate cfe-16. (without underscore).