### PR TITLE
Upgrade to Java 17 and fix vulnerable dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
     <log4j.version>2.23.1</log4j.version>
     <spring.boot.version>3.4.3</spring.boot.version>
     <spring.session.version>3.4.2</spring.session.version>
-    <junit.version>5.10.2</junit.version>
-    <junit.platform.version>1.10.2</junit.platform.version>
+    <junit.version>5.12.0</junit.version>
+    <junit.platform.version>1.12.0</junit.platform.version>
     <rlp_01.version>4.0.1</rlp_01.version>
     <rlp_03.version>3.0.0</rlp_03.version>
     <jakarta.servlet.version>6.1.0</jakarta.servlet.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <aspectj.version>1.9.21.1</aspectj.version>
     <log4j.version>2.23.1</log4j.version>
     <spring.boot.version>3.4.3</spring.boot.version>
-    <spring.session.version>2.7.4</spring.session.version>
+    <spring.session.version>3.4.2</spring.session.version>
     <junit.version>5.10.2</junit.version>
     <junit.platform.version>1.10.2</junit.platform.version>
     <rlp_01.version>4.0.1</rlp_01.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <sha1/>
     <aspectj.version>1.9.21.1</aspectj.version>
     <log4j.version>2.23.1</log4j.version>
-    <spring.boot.version>2.7.18</spring.boot.version>
+    <spring.boot.version>3.4.3</spring.boot.version>
     <spring.session.version>2.7.4</spring.session.version>
     <junit.version>5.10.2</junit.version>
     <junit.platform.version>1.10.2</junit.platform.version>

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,39 @@
       <artifactId>maven-bundle-plugin</artifactId>
       <version>6.0.0</version>
     </dependency>
+    <!-- Override maven-archiver dependency due to vulnerable deps in maven-bundle-plugin -->
+    <!-- https://mvnrepository.com/artifact/org.apache.maven/maven-archiver -->
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-archiver</artifactId>
+      <version>4.0.0-beta-1</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.iq80.snappy/snappy -->
+    <!-- Fix vulnerability in plexus-archiver:4.9.2, which is a dep in maven-archiver 4.0.0-beta-1 -->
+    <dependency>
+      <groupId>org.iq80.snappy</groupId>
+      <artifactId>snappy</artifactId>
+      <version>0.5</version>
+    </dependency>
+
+    <!-- https://mvnrepository.com/artifact/org.apache.maven.doxia/doxia-site-renderer -->
+    <dependency>
+      <groupId>org.apache.maven.doxia</groupId>
+      <artifactId>doxia-site-renderer</artifactId>
+      <version>2.0.0</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils -->
+    <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <version>1.10.1</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.codehaus.plexus/plexus-utils -->
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>4.0.2</version>
+    </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <groupId>com.teragrep</groupId>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>1.8</java.version>
+    <java.version>17</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <revision>0.0.1</revision>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <junit.platform.version>1.10.2</junit.platform.version>
     <rlp_01.version>4.0.1</rlp_01.version>
     <rlp_03.version>3.0.0</rlp_03.version>
-    <javax.servlet.version>4.0.1</javax.servlet.version>
+    <jakarta.servlet.version>6.1.0</jakarta.servlet.version>
     <jackson.version>2.16.2</jackson.version>
   </properties>
   <dependencies>
@@ -46,9 +46,9 @@
     </dependency>
     <!-- https://mvnrepository.com/artifact/javax.servlet/javax.servlet-api -->
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>${javax.servlet.version}</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${jakarta.servlet.version}</version>
     </dependency>
     <dependency>
       <groupId>com.teragrep</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>${log4j.version}</version>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/javax.servlet/javax.servlet-api -->
+    <!-- https://mvnrepository.com/artifact/jakarta.servlet/jakarta.servlet-api -->
     <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
@@ -152,43 +152,11 @@
       <version>2.0.9</version>
       <scope>test</scope>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.jetbrains/annotations -->
     <dependency>
-      <groupId>org.apache.felix</groupId>
-      <artifactId>maven-bundle-plugin</artifactId>
-      <version>6.0.0</version>
-    </dependency>
-    <!-- Override maven-archiver dependency due to vulnerable deps in maven-bundle-plugin -->
-    <!-- https://mvnrepository.com/artifact/org.apache.maven/maven-archiver -->
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-archiver</artifactId>
-      <version>4.0.0-beta-1</version>
-    </dependency>
-    <!-- https://mvnrepository.com/artifact/org.iq80.snappy/snappy -->
-    <!-- Fix vulnerability in plexus-archiver:4.9.2, which is a dep in maven-archiver 4.0.0-beta-1 -->
-    <dependency>
-      <groupId>org.iq80.snappy</groupId>
-      <artifactId>snappy</artifactId>
-      <version>0.5</version>
-    </dependency>
-
-    <!-- https://mvnrepository.com/artifact/org.apache.maven.doxia/doxia-site-renderer -->
-    <dependency>
-      <groupId>org.apache.maven.doxia</groupId>
-      <artifactId>doxia-site-renderer</artifactId>
-      <version>2.0.0</version>
-    </dependency>
-    <!-- https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils -->
-    <dependency>
-      <groupId>commons-beanutils</groupId>
-      <artifactId>commons-beanutils</artifactId>
-      <version>1.10.1</version>
-    </dependency>
-    <!-- https://mvnrepository.com/artifact/org.codehaus.plexus/plexus-utils -->
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
-      <version>4.0.2</version>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>26.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>maven-bundle-plugin</artifactId>
-      <version>5.1.9</version>
+      <version>6.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -152,12 +152,6 @@
       <version>2.0.9</version>
       <scope>test</scope>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/org.jetbrains/annotations -->
-    <dependency>
-      <groupId>org.jetbrains</groupId>
-      <artifactId>annotations</artifactId>
-      <version>26.0.2</version>
-    </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>

--- a/src/main/java/com/teragrep/cfe_16/AckManager.java
+++ b/src/main/java/com/teragrep/cfe_16/AckManager.java
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;

--- a/src/main/java/com/teragrep/cfe_16/EventManager.java
+++ b/src/main/java/com/teragrep/cfe_16/EventManager.java
@@ -66,7 +66,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;

--- a/src/main/java/com/teragrep/cfe_16/RequestHandler.java
+++ b/src/main/java/com/teragrep/cfe_16/RequestHandler.java
@@ -47,7 +47,7 @@
 package com.teragrep.cfe_16;
 
 import com.teragrep.cfe_16.bo.HeaderInfo;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/teragrep/cfe_16/SessionManager.java
+++ b/src/main/java/com/teragrep/cfe_16/SessionManager.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;

--- a/src/main/java/com/teragrep/cfe_16/ThirdParty/SyslogMessageSender/SyslogMessageSender.java
+++ b/src/main/java/com/teragrep/cfe_16/ThirdParty/SyslogMessageSender/SyslogMessageSender.java
@@ -33,8 +33,6 @@ import java.security.cert.X509Certificate;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * See <a href="http://tools.ietf.org/html/rfc6587">RFC 6587 - Transmission of Syslog Messages over TCP</a>
@@ -78,7 +76,7 @@ public class SyslogMessageSender extends AbstractSyslogMessageSender implements 
     private String postfix = "\n";
 
     @Override
-    public synchronized void sendMessage(@NotNull SyslogMessage message) throws IOException {
+    public synchronized void sendMessage(SyslogMessage message) throws IOException {
         sendCounter.incrementAndGet();
         long nanosBefore = System.nanoTime();
 
@@ -191,7 +189,7 @@ public class SyslogMessageSender extends AbstractSyslogMessageSender implements 
     @Override
     public void setSyslogServerHostname(final String syslogServerHostname) {
         this.syslogServerHostnameReference = new CachingReference<InetAddress>(DEFAULT_INET_ADDRESS_TTL_IN_NANOS) {
-            @Nullable
+
             @Override
             protected InetAddress newObject() {
                 try {
@@ -208,7 +206,6 @@ public class SyslogMessageSender extends AbstractSyslogMessageSender implements 
         this.syslogServerPort = syslogServerPort;
     }
 
-    @Nullable
     public String getSyslogServerHostname() {
         if (syslogServerHostnameReference == null)
             return null;

--- a/src/main/java/com/teragrep/cfe_16/ThirdParty/SyslogMessageSender/SyslogMessageSender.java
+++ b/src/main/java/com/teragrep/cfe_16/ThirdParty/SyslogMessageSender/SyslogMessageSender.java
@@ -20,9 +20,6 @@ import com.cloudbees.syslog.sender.AbstractSyslogMessageSender;
 import com.cloudbees.syslog.util.CachingReference;
 import com.cloudbees.syslog.util.IoUtils;
 
-import org.apache.maven.api.annotations.Nonnull;
-import org.apache.maven.api.annotations.Nullable;
-import org.apache.maven.api.annotations.ThreadSafe;
 import javax.net.SocketFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
@@ -36,13 +33,14 @@ import java.security.cert.X509Certificate;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * See <a href="http://tools.ietf.org/html/rfc6587">RFC 6587 - Transmission of Syslog Messages over TCP</a>
  *
  * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
  */
-@ThreadSafe
 public class SyslogMessageSender extends AbstractSyslogMessageSender implements Closeable  {
     public final static int SETTING_SOCKET_CONNECT_TIMEOUT_IN_MILLIS_DEFAULT_VALUE = 500;
     public final static int SETTING_MAX_RETRY = 2;
@@ -80,7 +78,7 @@ public class SyslogMessageSender extends AbstractSyslogMessageSender implements 
     private String postfix = "\n";
 
     @Override
-    public synchronized void sendMessage(@Nonnull SyslogMessage message) throws IOException {
+    public synchronized void sendMessage(@NotNull SyslogMessage message) throws IOException {
         sendCounter.incrementAndGet();
         long nanosBefore = System.nanoTime();
 

--- a/src/main/java/com/teragrep/cfe_16/ThirdParty/SyslogMessageSender/SyslogMessageSender.java
+++ b/src/main/java/com/teragrep/cfe_16/ThirdParty/SyslogMessageSender/SyslogMessageSender.java
@@ -20,9 +20,9 @@ import com.cloudbees.syslog.sender.AbstractSyslogMessageSender;
 import com.cloudbees.syslog.util.CachingReference;
 import com.cloudbees.syslog.util.IoUtils;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.ThreadSafe;
+import org.apache.maven.api.annotations.Nonnull;
+import org.apache.maven.api.annotations.Nullable;
+import org.apache.maven.api.annotations.ThreadSafe;
 import javax.net.SocketFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;

--- a/src/main/java/com/teragrep/cfe_16/TokenManager.java
+++ b/src/main/java/com/teragrep/cfe_16/TokenManager.java
@@ -46,7 +46,7 @@
 
 package com.teragrep.cfe_16;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/com/teragrep/cfe_16/rest/HECRestController.java
+++ b/src/main/java/com/teragrep/cfe_16/rest/HECRestController.java
@@ -51,7 +51,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.teragrep.cfe_16.RequestBodyCleaner;
 import com.teragrep.cfe_16.config.Configuration;
 import com.teragrep.cfe_16.service.HECService;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/teragrep/cfe_16/service/HECService.java
+++ b/src/main/java/com/teragrep/cfe_16/service/HECService.java
@@ -49,7 +49,7 @@ package com.teragrep.cfe_16.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 
 /**

--- a/src/main/java/com/teragrep/cfe_16/service/HECServiceImpl.java
+++ b/src/main/java/com/teragrep/cfe_16/service/HECServiceImpl.java
@@ -56,7 +56,7 @@ import com.teragrep.cfe_16.exceptionhandling.AuthenticationTokenMissingException
 import com.teragrep.cfe_16.exceptionhandling.ChannelNotFoundException;
 import com.teragrep.cfe_16.exceptionhandling.ChannelNotProvidedException;
 import com.teragrep.cfe_16.exceptionhandling.SessionNotFoundException;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
Fixes #11

- Move from Java 8 to Java 17
- Upgrade dependencies where possible
- Remove Maven Bundle Plugin in favor of targeted JetBrains Annotations
  - Nothing else was utilized from the Bundle Plugin, so it could be changed to an annotation plugin