### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: 8.0.292+10
+          java-version: 17.0.14+7
           distribution: 'adopt'
 
       - name: Run CI

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Maven Central
         uses: actions/setup-java@v4
         with:
-          java-version: 8.0.292+10
+          java-version: 17.0.14+7
           distribution: 'adopt'
 
       - name: Cache Local Maven Repository

--- a/.github/workflows/upload_release.yaml
+++ b/.github/workflows/upload_release.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup GitHub Packages
         uses: actions/setup-java@v3
         with:
-          java-version: 8.0.292+10
+          java-version: 17.0.14+7
           distribution: 'adopt'
 
       - name: Get version


### PR DESCRIPTION
Fixes #12

- Java versions changed from 8 to 17 on all GitHub Actions' workflows
- Uses the latest 17 Eclipse Temurin™ release found [here](https://adoptium.net/temurin/releases/?version=17)