### PR TITLE
Removes the spring-boot-devtools dependency

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -33,7 +33,6 @@ max.ack.age=20000
 max.session.age=30000
 poll.time=300000
 config.poll.time=5000
-spring.devtools.add-properties=false
 server.print.times=true
 ----
 

--- a/config/application.properties
+++ b/config/application.properties
@@ -7,5 +7,4 @@ max.ack.age=20000
 max.session.age=30000
 poll.time=300000
 config.poll.time=5000
-spring.devtools.add-properties=false
 server.print.times=true

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ HTTP Event Capture to RFC5424 CFE_16
+  ~ Copyright (C) 2019-2025 Suomen Kanuuna Oy
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  ~
+  ~
+  ~ Additional permission under GNU Affero General Public License version 3
+  ~ section 7
+  ~
+  ~ If you modify this Program, or any covered work, by linking or combining it
+  ~ with other code, such other code is not for that reason alone subject to any
+  ~ of the requirements of the GNU Affero GPL version 3 as long as this Program
+  ~ is the same Program as licensed from Suomen Kanuuna Oy without any additional
+  ~ modifications.
+  ~
+  ~ Supplemented terms under GNU Affero General Public License version 3
+  ~ section 7
+  ~
+  ~ Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+  ~ versions must be marked as "Modified version of" The Program.
+  ~
+  ~ Names of the licensors and authors may not be used for publicity purposes.
+  ~
+  ~ No rights are granted for use of trade names, trademarks, or service marks
+  ~ which are in The Program if any.
+  ~
+  ~ Licensee must indemnify licensors and authors for any liability that these
+  ~ contractual assumptions impose on licensors and authors.
+  ~
+  ~ To the extent this program is licensed as part of the Commercial versions of
+  ~ Teragrep, the applicable Commercial License may apply to this file if you as
+  ~ a licensee so wish it.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -87,12 +133,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-log4j2</artifactId>
       <version>${spring.boot.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-devtools</artifactId>
-      <version>${spring.boot.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/resources/application.properties.example
+++ b/src/main/resources/application.properties.example
@@ -7,5 +7,4 @@ max.ack.age=20000
 max.session.age=30000
 poll.time=300000
 config.poll.time=5000
-spring.devtools.add-properties=false
 server.print.times=true

--- a/src/test/java/com/teragrep/cfe_16/it/AckManagerIT.java
+++ b/src/test/java/com/teragrep/cfe_16/it/AckManagerIT.java
@@ -83,8 +83,7 @@ import static org.junit.Assert.*;
         "max.ack.age=20000", 
         "max.session.age=30000", 
         "poll.time=30000", 
-        "spring.devtools.add-properties=false", 
-        "server.print.times=true" 
+        "server.print.times=true"
         })
 public class AckManagerIT {
     private static final Logger LOGGER = LoggerFactory.getLogger(AckManagerIT.class);

--- a/src/test/java/com/teragrep/cfe_16/it/SendEventsIT.java
+++ b/src/test/java/com/teragrep/cfe_16/it/SendEventsIT.java
@@ -75,8 +75,7 @@ import java.util.concurrent.atomic.AtomicInteger;
         "max.ack.age=20000", 
         "max.session.age=30000", 
         "poll.time=30000", 
-        "spring.devtools.add-properties=false", 
-        "server.print.times=true" 
+        "server.print.times=true"
         })
 @SpringBootTest
 public class SendEventsIT implements Runnable {

--- a/src/test/java/com/teragrep/cfe_16/it/ServiceAndEventManagerIT.java
+++ b/src/test/java/com/teragrep/cfe_16/it/ServiceAndEventManagerIT.java
@@ -89,8 +89,7 @@ import static org.junit.Assert.*;
 		"max.ack.age=20000", 
 		"max.session.age=30000", 
 		"poll.time=30000", 
-		"spring.devtools.add-properties=false", 
-		"server.print.times=true" 
+		"server.print.times=true"
 		})
 public class ServiceAndEventManagerIT {
     private static final Logger LOGGER = LoggerFactory.getLogger(ServiceAndEventManagerIT.class);


### PR DESCRIPTION
The dependency doesn't seems to be used in anyway, so it should be removed to to limit the possible vulnerability vectors

- Also adds the LICENSE header to the `pom.xml`

CI fails, because #15 hasn't been merged yet, causing Java 17 to not like the mocking tests