### PR TITLE
Use List<SyslogMessage> for AbstractSender.sendMessages instead of Array

### DIFF
--- a/src/main/java/com/teragrep/cfe_16/EventManager.java
+++ b/src/main/java/com/teragrep/cfe_16/EventManager.java
@@ -170,8 +170,7 @@ public class EventManager {
         // create a new object to avoid blocking of threads because
         // the SyslogMessageSender.sendMessage() is synchronized
         try {
-            SyslogMessage[] messages = syslogMessages.toArray(new SyslogMessage[syslogMessages.size()]);
-            this.connection.sendMessages(messages);
+            this.connection.sendMessages(syslogMessages);
         }
         catch (IOException e) {
             throw new InternalServerErrorException(e);

--- a/src/main/java/com/teragrep/cfe_16/connection/AbstractConnection.java
+++ b/src/main/java/com/teragrep/cfe_16/connection/AbstractConnection.java
@@ -49,6 +49,7 @@ import com.cloudbees.syslog.SyslogMessage;
 import com.cloudbees.syslog.sender.AbstractSyslogMessageSender;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * An abstract connection class for sending batch messages.
@@ -69,7 +70,7 @@ public abstract class AbstractConnection extends AbstractSyslogMessageSender {
      * 
      * @param syslogMessages
      */
-    public abstract void sendMessages(SyslogMessage[] syslogMessages) throws IOException;
+    public abstract void sendMessages(List<SyslogMessage> syslogMessages) throws IOException;
 
     @Override
     public void setSyslogServerHostname(String syslogServerHostname) {

--- a/src/main/java/com/teragrep/cfe_16/connection/RelpConnection.java
+++ b/src/main/java/com/teragrep/cfe_16/connection/RelpConnection.java
@@ -48,6 +48,7 @@ package com.teragrep.cfe_16.connection;
 import com.cloudbees.syslog.SyslogMessage;
 import com.teragrep.rlp_01.RelpBatch;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,7 +125,7 @@ public class RelpConnection extends AbstractConnection {
     }
 
     @Override
-    synchronized public void sendMessages(SyslogMessage[] syslogMessages) throws IOException {
+    synchronized public void sendMessages(List<SyslogMessage> syslogMessages) throws IOException {
         final RelpBatch relpBatch = new RelpBatch();
         for (SyslogMessage syslogMessage : syslogMessages) {
             relpBatch.insert(syslogMessage.toRfc5424SyslogMessage().getBytes(StandardCharsets.UTF_8));

--- a/src/main/java/com/teragrep/cfe_16/connection/TcpConnection.java
+++ b/src/main/java/com/teragrep/cfe_16/connection/TcpConnection.java
@@ -47,6 +47,7 @@ package com.teragrep.cfe_16.connection;
 
 import com.cloudbees.syslog.SyslogMessage;
 import com.cloudbees.syslog.sender.TcpSyslogMessageSender;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +66,7 @@ public class TcpConnection extends AbstractConnection {
     }
 
     @Override
-    public void sendMessages(SyslogMessage[] syslogMessages) throws IOException {
+    public void sendMessages(List<SyslogMessage> syslogMessages) throws IOException {
         LOGGER.debug("Sending messages");
         for (SyslogMessage syslogMessage : syslogMessages) {
             this.sender.sendMessage(syslogMessage);

--- a/src/main/java/com/teragrep/cfe_16/connection/UdpConnection.java
+++ b/src/main/java/com/teragrep/cfe_16/connection/UdpConnection.java
@@ -47,6 +47,7 @@ package com.teragrep.cfe_16.connection;
 
 import com.cloudbees.syslog.SyslogMessage;
 import com.cloudbees.syslog.sender.UdpSyslogMessageSender;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +66,7 @@ public class UdpConnection extends AbstractConnection {
     }
 
     @Override
-    public void sendMessages(SyslogMessage[] syslogMessages) throws IOException {
+    public void sendMessages(List<SyslogMessage> syslogMessages) throws IOException {
         LOGGER.debug("Sending messages");
         for (SyslogMessage syslogMessage : syslogMessages) {
             this.sender.sendMessage(syslogMessage);


### PR DESCRIPTION
Closes #26 

Use the List of SyslogMessages instead of converting in to an Array