### PR TITLE
Remove beforeEach and afterEach test methods

### DIFF
--- a/src/main/java/com/teragrep/cfe_16/config/Configuration.java
+++ b/src/main/java/com/teragrep/cfe_16/config/Configuration.java
@@ -83,6 +83,26 @@ public class Configuration {
 
     }
 
+    public Configuration(
+            final String syslogHost,
+            final int syslogPort,
+            final int maxAckValue,
+            final int maxAckAge,
+            final int maxSessionAge,
+            final int maxChannels,
+            final long pollTime,
+            final boolean printTimes
+    ) {
+        this.syslogHost = syslogHost;
+        this.syslogPort = syslogPort;
+        this.maxAckValue = maxAckValue;
+        this.maxAckAge = maxAckAge;
+        this.maxSessionAge = maxSessionAge;
+        this.maxChannels = maxChannels;
+        this.pollTime = pollTime;
+        this.printTimes = printTimes;
+    }
+
     @Bean
     public String syslogHost() {
         return this.syslogHost;

--- a/src/main/java/com/teragrep/cfe_16/connection/RelpConnection.java
+++ b/src/main/java/com/teragrep/cfe_16/connection/RelpConnection.java
@@ -84,7 +84,7 @@ public final class RelpConnection implements Closeable {
         this.connect();
     }
 
-    synchronized private void connect() {
+    synchronized public void connect() {
         boolean notConnected = true;
         while (notConnected) {
             boolean connected = false;

--- a/src/main/java/com/teragrep/cfe_16/rest/HECRestController.java
+++ b/src/main/java/com/teragrep/cfe_16/rest/HECRestController.java
@@ -73,11 +73,15 @@ public class HECRestController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HECRestController.class);
     private final ObjectMapper objectMapper = new ObjectMapper();
-    @Autowired
-    private HECService service;
+
+    private final HECService service;
+    private final Configuration configuration;
 
     @Autowired
-    private Configuration configuration;
+    public HECRestController(final HECService service, final Configuration configuration) {
+        this.service = service;
+        this.configuration = configuration;
+    }
 
     @RequestMapping(
             value = "services/collector",

--- a/src/test/java/com/teragrep/cfe_16/EventDataToSyslogMessageTest.java
+++ b/src/test/java/com/teragrep/cfe_16/EventDataToSyslogMessageTest.java
@@ -69,7 +69,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 /**
  * Tests the functionality of the eventData.toSyslogMessage method
  */
-public class EventDataToSyslogMessageTest {
+class EventDataToSyslogMessageTest {
 
     @Test
     @DisplayName("test fields when time is provided in HECRecord")

--- a/src/test/java/com/teragrep/cfe_16/HECBatchTest.java
+++ b/src/test/java/com/teragrep/cfe_16/HECBatchTest.java
@@ -61,13 +61,13 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
-class HECBatchTest {
-
-    private static final String channel1 = "CHANNEL_11111";
-    private static final String authToken1 = "AUTH_TOKEN_12223";
+final class HECBatchTest {
 
     @Test
-    public void toHECRecordListTest() {
+    void toHECRecordListTest() {
+        final String channel1 = "CHANNEL_11111";
+        final String authToken1 = "AUTH_TOKEN_12223";
+
         final String allEventsInJson = "{\"sourcetype\": \"mysourcetype\", \"event\": \"Hello, world!\", \"host\": \"localhost\", \"source\": \"mysource\", \"index\": \"myindex\", \"time\": 123456}";
         final HECRecord supposedResponse = new HECRecordImpl(
                 channel1,
@@ -105,7 +105,10 @@ class HECBatchTest {
      * Tests for JsonSyntaxException
      */
     @Test
-    public void toHECRecordListUsesAStubIfParsingFailsWithMalformedJSONTest() {
+    void toHECRecordListUsesAStubIfParsingFailsWithMalformedJSONTest() {
+        final String channel1 = "CHANNEL_11111";
+        final String authToken1 = "AUTH_TOKEN_12223";
+
         final String allEventsInJson = "{\"sourcetype\": \"mysourcetype\", \"event\": {{{{}}}}";
         final HECBatch HECBatch = new HECBatch(
                 authToken1,
@@ -121,7 +124,10 @@ class HECBatchTest {
      * Tests for EventStub existence, since the Event should not be valid
      */
     @Test
-    public void toHECRecordListUsesAStubIfParsingFailsWithEmptyJSONTest() {
+    void toHECRecordListUsesAStubIfParsingFailsWithEmptyJSONTest() {
+        final String channel1 = "CHANNEL_11111";
+        final String authToken1 = "AUTH_TOKEN_12223";
+
         final String allEventsInJson = "{\"sourcetype\": \"mysourcetype\", \"event\": null}";
         final String supposedResponse = "Event field was not textual";
         final HECBatch HECBatch = new HECBatch(
@@ -139,7 +145,10 @@ class HECBatchTest {
     }
 
     @Test
-    public void noEventFieldInRequestTest() {
+    void noEventFieldInRequestTest() {
+        final String channel1 = "CHANNEL_11111";
+        final String authToken1 = "AUTH_TOKEN_12223";
+
         final String allEventsInJson = "{\"sourcetype\": \"mysourcetype\", \"host\": \"localhost\", \"source\": \"mysource\", \"index\": \"myindex\"}";
         final HECBatch HECBatch = new HECBatch(
                 authToken1,
@@ -152,7 +161,10 @@ class HECBatchTest {
     }
 
     @Test
-    public void eventFieldBlankInRequestTest() {
+    void eventFieldBlankInRequestTest() {
+        final String channel1 = "CHANNEL_11111";
+        final String authToken1 = "AUTH_TOKEN_12223";
+
         final String allEventsInJson = "{\"sourcetype\": \"mysourcetype\", \"event\": \"\", \"host\": \"localhost\", \"source\": \"mysource\", \"index\": \"myindex\"}";
         final HECBatch HECBatch = new HECBatch(
                 authToken1,

--- a/src/test/java/com/teragrep/cfe_16/SessionManagerTests.java
+++ b/src/test/java/com/teragrep/cfe_16/SessionManagerTests.java
@@ -48,30 +48,20 @@ package com.teragrep.cfe_16;
 import com.teragrep.cfe_16.bo.Session;
 import com.teragrep.cfe_16.config.Configuration;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /*
  * Tests the functionality of SessionManager
  */
-public class SessionManagerTests {
-
-    private SessionManager sessionManager;
-
-    /*
-     * A SessionManager is initialized
-     */
-    @BeforeEach
-    public void initialize() {
-        sessionManager = new SessionManager(new Configuration());
-    }
+final class SessionManagerTests {
 
     /*
      * Tests creating a session with SessionManager and getting that same session
      * from SessionManager
      */
     @Test
-    public void createSessionAndGetItWithAuthTokenTest() {
+    void createSessionAndGetItWithAuthTokenTest() {
+        final SessionManager sessionManager = new SessionManager(new Configuration());
 
         String authToken1 = "AUTH_TOKEN_12345";
         String authToken2 = "AUTH_TOKEN_54321";
@@ -92,7 +82,9 @@ public class SessionManagerTests {
     }
 
     @Test
-    public void sessionCreationAndDeletionTests() {
+    void sessionCreationAndDeletionTests() {
+        final SessionManager sessionManager = new SessionManager(new Configuration());
+
         Session session = sessionManager.createSession("AUTH");
         Assertions.assertTrue(session.addChannel(Session.DEFAULT_CHANNEL));
         Assertions.assertFalse(session.addChannel(Session.DEFAULT_CHANNEL));

--- a/src/test/java/com/teragrep/cfe_16/TokenManagerTests.java
+++ b/src/test/java/com/teragrep/cfe_16/TokenManagerTests.java
@@ -53,16 +53,15 @@ import org.springframework.mock.web.MockHttpServletRequest;
 /*
  * Tests the functionality of TokenManager
  */
-public class TokenManagerTests {
-
-    TokenManager manager = new TokenManager();
+final class TokenManagerTests {
 
     /*
      * Tests TokenManager's tokenIsMissing() method which checks if
      * HttpServletRequest's header has an authentication token in it.
      */
     @Test
-    public void tokenCheckingTest() {
+    void tokenCheckingTest() {
+        final TokenManager manager = new TokenManager();
 
         MockHttpServletRequest requestWithHttpHeaderAuth = new MockHttpServletRequest();
         MockHttpServletRequest requestWithBasicAuth = new MockHttpServletRequest();
@@ -84,7 +83,9 @@ public class TokenManagerTests {
      * format.
      */
     @Test
-    public void basicAuthCheckingTest() {
+    void basicAuthCheckingTest() {
+        final TokenManager manager = new TokenManager();
+
         String authToken = "AUTH_TOKEN_11111";
         String basicAuthHeader = "Basic x:" + authToken;
 
@@ -99,7 +100,9 @@ public class TokenManagerTests {
      * authentication token when it is given in basic authentication format.
      */
     @Test
-    public void getTokenFromBasicAuthTest() {
+    void getTokenFromBasicAuthTest() {
+        final TokenManager manager = new TokenManager();
+
         String authToken = "AUTH_TOKEN_11111";
         String basicAuthCredentials = "x:" + authToken;
         String credentialsEncoded = Base64.getEncoder().encodeToString(basicAuthCredentials.getBytes());

--- a/src/test/java/com/teragrep/cfe_16/it/AcknowledgementsIT.java
+++ b/src/test/java/com/teragrep/cfe_16/it/AcknowledgementsIT.java
@@ -52,20 +52,8 @@ import com.teragrep.cfe_16.bo.Ack;
 import com.teragrep.cfe_16.bo.Session;
 import com.teragrep.cfe_16.config.Configuration;
 import com.teragrep.cfe_16.exceptionhandling.ServerIsBusyException;
-import com.teragrep.cfe_16.server.TestServer;
-import com.teragrep.cfe_16.server.TestServerFactory;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.atomic.AtomicLong;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.TestPropertySource;
 
 import java.util.Map;
 import tools.jackson.databind.exc.InvalidFormatException;
@@ -73,138 +61,125 @@ import tools.jackson.databind.exc.InvalidFormatException;
 /*
  * Tests the functionality of Acknowledgements
  */
-@SpringBootTest
-@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
-@TestPropertySource(properties = {
-        "syslog.server.host=127.0.0.1",
-        "syslog.server.port=1234",
-        "max.channels=1000000",
-        "max.ack.value=1000000",
-        "max.ack.age=20000",
-        "max.session.age=30000",
-        "poll.time=30000",
-        "server.print.times=true"
-})
-public class AcknowledgementsIT {
+final class AcknowledgementsIT {
 
-    private String authToken1;
-    private String authToken2;
-
-    private String channel1;
-    private String channel2;
-
-    @Autowired
-    private Acknowledgements acknowledgements;
-    private static final int SERVER_PORT = 1234;
-    private static final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
-    private static final AtomicLong openCount = new AtomicLong();
-    private static final AtomicLong closeCount = new AtomicLong();
-    private static TestServer server;
-
-    @BeforeAll
-    public static void init() {
-        final TestServerFactory serverFactory = new TestServerFactory();
-
-        server = Assertions
-                .assertDoesNotThrow(() -> serverFactory.create(SERVER_PORT, messageList, openCount, closeCount));
-
-        server.run();
-    }
-
-    @AfterAll
-    public static void close() {
-        Assertions.assertDoesNotThrow(() -> server.close());
-    }
-
-    /*
-     * Initializes 2 channels. getCurrentAckValue in channel 1 is called 3 times
-     * which means that the next Ack id given to a sent event should be 3.
-     */
-    @BeforeEach
-    public void initialize() {
-
-        authToken1 = "AUTH_TOKEN_11111";
-        authToken2 = "AUTH_TOKEN_22222";
-
-        channel1 = "CHANNEL_11111";
-        channel2 = "CHANNEL_22222";
-
-    }
-
-    /*
-     * In initialize() we call channel 1's getCurrentAckValue 3 times, so the next
-     * time we call it, the currentAckValue() should return 3 and increase the ack
-     * value by 1, so the next time it will be 4. We have not called
-     * getCurrentAckValue() in channel2 yet, so it should be 0.
-     */
     @Test
-    public void getCurrentAckValueTest() {
+    void getCurrentAckValueTest() {
+        final Configuration configuration = new Configuration(
+                "localhost",
+                1234,
+                1000000,
+                20000,
+                30000,
+                1000000,
+                1000000,
+                true
+        );
+        final Acknowledgements acknowledgements = new Acknowledgements(configuration);
+
+        final String authToken1 = "AUTH_TOKEN_11111";
+        final String authToken2 = "AUTH_TOKEN_22222";
+        final String channel1 = "CHANNEL_11111";
+        final String channel2 = "CHANNEL_22222";
+
         int currentAckValue;
-        currentAckValue = acknowledgements.getCurrentAckValue(this.authToken1, this.channel1);
-        acknowledgements.incrementAckValue(this.authToken1, this.channel1);
+        currentAckValue = acknowledgements.getCurrentAckValue(authToken1, channel1);
+        acknowledgements.incrementAckValue(authToken1, channel1);
 
-        currentAckValue = acknowledgements.getCurrentAckValue(this.authToken1, this.channel1);
-        acknowledgements.incrementAckValue(this.authToken1, this.channel1);
+        currentAckValue = acknowledgements.getCurrentAckValue(authToken1, channel1);
+        acknowledgements.incrementAckValue(authToken1, channel1);
 
-        currentAckValue = acknowledgements.getCurrentAckValue(this.authToken1, this.channel1);
-        acknowledgements.incrementAckValue(this.authToken1, this.channel1);
+        currentAckValue = acknowledgements.getCurrentAckValue(authToken1, channel1);
+        acknowledgements.incrementAckValue(authToken1, channel1);
 
-        currentAckValue = acknowledgements.getCurrentAckValue(this.authToken1, this.channel1);
-        acknowledgements.incrementAckValue(this.authToken1, this.channel1);
+        currentAckValue = acknowledgements.getCurrentAckValue(authToken1, channel1);
+        acknowledgements.incrementAckValue(authToken1, channel1);
 
         Assertions.assertEquals(3, currentAckValue, "channel1 current ack value should be 3");
 
-        currentAckValue = acknowledgements.getCurrentAckValue(this.authToken1, this.channel1);
-        acknowledgements.incrementAckValue(this.authToken1, this.channel1);
+        currentAckValue = acknowledgements.getCurrentAckValue(authToken1, channel1);
+        acknowledgements.incrementAckValue(authToken1, channel1);
         Assertions.assertEquals(4, currentAckValue, "channel1 current ack value should be 4");
 
-        currentAckValue = acknowledgements.getCurrentAckValue(this.authToken2, this.channel2);
+        currentAckValue = acknowledgements.getCurrentAckValue(authToken2, channel2);
         Assertions.assertEquals(0, currentAckValue, "channel2 current ack value should be 0");
     }
 
-    /*
-     * First we acknowledge the Ack with an id of 0 in channel 1, then we test that
-     * it is indeed acknowledged. All the other Acks should not be acknowledged. If
-     * Ack id is not used at all, isAckAcknowledged should return false.
+    /**
+     * First we acknowledge the Ack with an id of 0 in channel 1, then we test that it is indeed acknowledged. All the
+     * other Acks should not be acknowledged. If Ack id is not used at all, isAckAcknowledged should return false.
      */
     @Test
-    public void acknowledgeTest() {
-        acknowledgements.initializeContext(this.authToken1, this.channel1);
-        acknowledgements.addAck(this.authToken1, this.channel1, new Ack(0, false));
-        acknowledgements.acknowledge(this.authToken1, this.channel1, 0);
+    void acknowledgeTest() {
+        final Configuration configuration = new Configuration(
+                "localhost",
+                1234,
+                1000000,
+                20000,
+                30000,
+                1000000,
+                1000000,
+                true
+        );
+        final Acknowledgements acknowledgements = new Acknowledgements(configuration);
+
+        final String authToken1 = "AUTH_TOKEN_11111";
+        final String authToken2 = "AUTH_TOKEN_22222";
+        final String channel1 = "CHANNEL_11111";
+        final String channel2 = "CHANNEL_22222";
+
+        acknowledgements.initializeContext(authToken1, channel1);
+        acknowledgements.addAck(authToken1, channel1, new Ack(0, false));
+        acknowledgements.acknowledge(authToken1, channel1, 0);
         Assertions
                 .assertTrue(
 
-                        acknowledgements.isAckAcknowledged(this.authToken1, this.channel1, 0), "ackId 0 should be acknowledged for channel 1"
+                        acknowledgements.isAckAcknowledged(authToken1, channel1, 0), "ackId 0 should be acknowledged for channel 1"
                 );
         Assertions
                 .assertFalse(
 
-                        acknowledgements.isAckAcknowledged(this.authToken1, this.channel1, 1), "ackId 1 should not be acknowledged for channel 1"
+                        acknowledgements.isAckAcknowledged(authToken1, channel1, 1), "ackId 1 should not be acknowledged for channel 1"
                 );
         Assertions
                 .assertFalse(
 
-                        acknowledgements.isAckAcknowledged(this.authToken1, this.channel1, 10), "ackId 10 is not used yet for channel 1, so isAckAcknowledged should return false"
+                        acknowledgements.isAckAcknowledged(authToken1, channel1, 10), "ackId 10 is not used yet for channel 1, so isAckAcknowledged should return false"
                 );
-        acknowledgements.incrementAckValue(this.authToken1, this.channel1);
-        acknowledgements.initializeContext(this.authToken2, this.channel2);
+        acknowledgements.incrementAckValue(authToken1, channel1);
+        acknowledgements.initializeContext(authToken2, channel2);
         Assertions
                 .assertFalse(
 
-                        acknowledgements.isAckAcknowledged(this.authToken2, this.channel2, 0), "ackId 0 is not used yet for channel 2 so isAckAcknowledged should return false"
+                        acknowledgements.isAckAcknowledged(authToken2, channel2, 0), "ackId 0 is not used yet for channel 2 so isAckAcknowledged should return false"
                 );
     }
 
-    /*
-     * Tests getting the Ack statuses from Acknowledgements. First we create the request
-     * bodies and the supposed responses as strings. Then we create the nodes for
-     * the requests and read the strings into the node object. After that
-     * Acknowledgements' getRequestedAckStatuses() is called with the JsonNode requests
-     * and the response is compared to the supposed responses.
+    /**
+     * Tests getting the Ack statuses from Acknowledgements. First we create the request bodies and the supposed
+     * responses as strings. Then we create the nodes for the requests and read the strings into the node object. After
+     * that Acknowledgements' getRequestedAckStatuses() is called with the JsonNode requests and the response is
+     * compared to the supposed responses.
      */
     @Test
-    public void getRequestedAckStatusesTest() {
+    void getRequestedAckStatusesTest() {
+        final Configuration configuration = new Configuration(
+                "localhost",
+                1234,
+                1000000,
+                20000,
+                30000,
+                1000000,
+                1000000,
+                true
+        );
+        final Acknowledgements acknowledgements = new Acknowledgements(configuration);
+
+        final String authToken1 = "AUTH_TOKEN_11111";
+        final String authToken2 = "AUTH_TOKEN_22222";
+        final String channel1 = "CHANNEL_11111";
+        final String channel2 = "CHANNEL_22222";
+
         final String requestAsString = "{\"acks\": [1,3,4]}";
         final String notIntRequestAsString = "{\"acks\": [\"a\",\"b\",\"c\"]}";
         final String faultyRequestAsString = "{\"test\": [1,3,4]}";
@@ -215,21 +190,21 @@ public class AcknowledgementsIT {
         final JsonNode queryNode;
         final JsonNode faultyNode;
         final JsonNode notIntNode;
-        acknowledgements.initializeContext(this.authToken1, this.channel1);
-        Assertions.assertTrue(acknowledgements.addAck(this.authToken1, this.channel1, new Ack(1, false)));
-        Assertions.assertTrue(acknowledgements.acknowledge(this.authToken1, this.channel1, 1));
+        acknowledgements.initializeContext(authToken1, channel1);
+        Assertions.assertTrue(acknowledgements.addAck(authToken1, channel1, new Ack(1, false)));
+        Assertions.assertTrue(acknowledgements.acknowledge(authToken1, channel1, 1));
 
         queryNode = Assertions.assertDoesNotThrow(() -> mapper.readTree(requestAsString));
         faultyNode = Assertions.assertDoesNotThrow(() -> mapper.readTree(faultyRequestAsString));
         notIntNode = Assertions.assertDoesNotThrow(() -> mapper.readTree(notIntRequestAsString));
 
         Assertions
-                .assertEquals(emptyJsonNode, acknowledgements.getRequestedAckStatuses(this.authToken1, "", null), "getRequestedAckStatuses should return null, when providing a null value as a parameter");
+                .assertEquals(emptyJsonNode, acknowledgements.getRequestedAckStatuses(authToken1, "", null), "getRequestedAckStatuses should return null, when providing a null value as a parameter");
 
         Assertions
                 .assertEquals(
                         supposedResponseAsStringOneTrue, acknowledgements
-                                .getRequestedAckStatuses(this.authToken1, this.channel1, queryNode)
+                                .getRequestedAckStatuses(authToken1, channel1, queryNode)
                                 .toString(),
                         "ackId 1 status should be true on channel1, others should be false."
                 );
@@ -238,90 +213,101 @@ public class AcknowledgementsIT {
                 .assertEquals(
 
                         supposedResponseAsStringAllFalse, acknowledgements
-                                .getRequestedAckStatuses(this.authToken1, this.channel1, queryNode)
+                                .getRequestedAckStatuses(authToken1, channel1, queryNode)
                                 .toString(),
                         "ackId 1 status should be false on channel1 after requesting it's status once. All others should be false as well"
                 );
 
-        acknowledgements.initializeContext(this.authToken2, this.channel2);
+        acknowledgements.initializeContext(authToken2, channel2);
         Assertions
                 .assertEquals(
                         supposedResponseAsStringAllFalse, acknowledgements
-                                .getRequestedAckStatuses(this.authToken2, this.channel2, queryNode)
+                                .getRequestedAckStatuses(authToken2, channel2, queryNode)
                                 .toString(),
                         "All ack statuses should be false for channel2"
                 );
 
         Assertions
                 .assertEquals(
-                        emptyJsonNode, acknowledgements
-                                .getRequestedAckStatuses(this.authToken1, this.channel1, emptyJsonNode),
-                        "An empty JsonNode should be returned when querying with an empty JsonNode"
+                        emptyJsonNode, acknowledgements.getRequestedAckStatuses(authToken1, channel1, emptyJsonNode), "An empty JsonNode should be returned when querying with an empty JsonNode"
                 );
 
         Assertions
                 .assertEquals(
 
-                        emptyJsonNode, acknowledgements
-                                .getRequestedAckStatuses(this.authToken1, this.channel1, faultyNode),
-                        "An empty JsonNode should be returned when querying with a JsonNode that has no \"acks\" field in it."
+                        emptyJsonNode, acknowledgements.getRequestedAckStatuses(authToken1, channel1, faultyNode), "An empty JsonNode should be returned when querying with a JsonNode that has no \"acks\" field in it."
                 );
 
         Assertions
                 .assertThrowsExactly(
                         InvalidFormatException.class,
-                        () -> acknowledgements.getRequestedAckStatuses(this.authToken1, this.channel1, notIntNode)
+                        () -> acknowledgements.getRequestedAckStatuses(authToken1, channel1, notIntNode)
                 );
     }
 
-    public void getCurrentAckValueAndIncrementTest() {
-        Acknowledgements acknowledgements1 = new Acknowledgements(new Configuration());
-        Acknowledgements acknowledgements2 = new Acknowledgements(new Configuration());
+    @Test
+    void getCurrentAckValueAndIncrementTest() {
+        final Configuration configuration = new Configuration(
+                "localhost",
+                1234,
+                1000000,
+                20000,
+                30000,
+                1000000,
+                1000000,
+                true
+        );
+        final String authToken1 = "AUTH_TOKEN_11111";
+
+        final Acknowledgements acknowledgements1 = new Acknowledgements(configuration);
+        final Acknowledgements acknowledgements2 = new Acknowledgements(configuration);
 
         Assertions
-                .assertEquals(0, acknowledgements1.getCurrentAckValue(this.authToken1, Session.DEFAULT_CHANNEL), "Acknowledgements 1 should return 0");
-        acknowledgements1.incrementAckValue(this.authToken1, Session.DEFAULT_CHANNEL);
+                .assertEquals(0, acknowledgements1.getCurrentAckValue(authToken1, Session.DEFAULT_CHANNEL), "Acknowledgements 1 should return 0");
+        acknowledgements1.incrementAckValue(authToken1, Session.DEFAULT_CHANNEL);
         Assertions
-                .assertEquals(1, acknowledgements1.getCurrentAckValue(this.authToken1, Session.DEFAULT_CHANNEL), "Acknowledgements 1 should return 1");
+                .assertEquals(1, acknowledgements1.getCurrentAckValue(authToken1, Session.DEFAULT_CHANNEL), "Acknowledgements 1 should return 1");
 
         Assertions
-                .assertEquals(0, acknowledgements2.getCurrentAckValue(this.authToken1, Session.DEFAULT_CHANNEL), "Acknowledgements 2 should return 0");
-        acknowledgements2.incrementAckValue(this.authToken1, Session.DEFAULT_CHANNEL);
+                .assertEquals(0, acknowledgements2.getCurrentAckValue(authToken1, Session.DEFAULT_CHANNEL), "Acknowledgements 2 should return 0");
+        acknowledgements2.incrementAckValue(authToken1, Session.DEFAULT_CHANNEL);
         Assertions
-                .assertEquals(1, acknowledgements2.getCurrentAckValue(this.authToken1, Session.DEFAULT_CHANNEL), "Acknowledgements 2 should return 1");
-
+                .assertEquals(1, acknowledgements2.getCurrentAckValue(authToken1, Session.DEFAULT_CHANNEL), "Acknowledgements 2 should return 1");
     }
 
-    /*
-     * Tests deleting the Ack from Acknowledgements. First we get the list that is
-     * currently in the Acknowledgements and save it to list1 variable. After that we
-     * delete an Ack from the Acknowledgements's list, then we get the list from
-     * Acknowledgements again and save it to list2 variable. These 2 lists are then
-     * compared to each other.
+    /**
+     * Tests deleting the Ack from Acknowledgements. First we get the list that is currently in the Acknowledgements and
+     * save it to list1 variable. After that we delete an Ack from the Acknowledgements's list, then we get the list
+     * from Acknowledgements again and save it to list2 variable. These 2 lists are then compared to each other.
      */
     @Test
-    public void deleteAckTest() {
-        Acknowledgements acknowledgements1 = new Acknowledgements(new Configuration());
-        Acknowledgements acknowledgements2 = new Acknowledgements(new Configuration());
+    void deleteAckTest() {
+        final String authToken1 = "AUTH_TOKEN_11111";
+        final String authToken2 = "AUTH_TOKEN_22222";
+        final String channel1 = "CHANNEL_11111";
+        final String channel2 = "CHANNEL_22222";
 
-        acknowledgements1.initializeContext(this.authToken1, this.channel1);
-        Assertions.assertTrue(acknowledgements1.addAck(this.authToken1, this.channel1, new Ack(0, false)));
-        Assertions.assertTrue(acknowledgements1.addAck(this.authToken1, this.channel1, new Ack(1, false)));
+        final Acknowledgements acknowledgements1 = new Acknowledgements(new Configuration());
+        final Acknowledgements acknowledgements2 = new Acknowledgements(new Configuration());
 
-        Map<Integer, Ack> list1 = acknowledgements1.getAckList(this.authToken1, this.channel1);
-        int list1Size = acknowledgements1.getAckListSize(this.authToken1, this.channel1);
+        acknowledgements1.initializeContext(authToken1, channel1);
+        Assertions.assertTrue(acknowledgements1.addAck(authToken1, channel1, new Ack(0, false)));
+        Assertions.assertTrue(acknowledgements1.addAck(authToken1, channel1, new Ack(1, false)));
+
+        Map<Integer, Ack> list1 = acknowledgements1.getAckList(authToken1, channel1);
+        int list1Size = acknowledgements1.getAckListSize(authToken1, channel1);
         Assertions.assertEquals(2, list1Size, "Ack list 1 size should be 2.");
 
         Ack deletedAck = list1.values().iterator().next();
 
-        acknowledgements2.initializeContext(this.authToken2, this.channel2);
-        Assertions.assertTrue(acknowledgements2.addAck(this.authToken2, this.channel2, new Ack(0, false)));
+        acknowledgements2.initializeContext(authToken2, channel2);
+        Assertions.assertTrue(acknowledgements2.addAck(authToken2, channel2, new Ack(0, false)));
 
-        acknowledgements2.initializeContext(this.authToken2, this.channel2);
-        Assertions.assertTrue(acknowledgements2.addAck(this.authToken2, this.channel2, new Ack(1, false)));
+        acknowledgements2.initializeContext(authToken2, channel2);
+        Assertions.assertTrue(acknowledgements2.addAck(authToken2, channel2, new Ack(1, false)));
 
-        acknowledgements2.deleteAckFromList(this.authToken2, this.channel2, deletedAck);
-        Map<Integer, Ack> list2 = acknowledgements2.getAckList(this.authToken2, this.channel2);
+        acknowledgements2.deleteAckFromList(authToken2, channel2, deletedAck);
+        Map<Integer, Ack> list2 = acknowledgements2.getAckList(authToken2, channel2);
         int list2Size = list2.size();
 
         Assertions.assertNotSame(list1.toString(), list2.toString(), "Ack lists should not be same");
@@ -329,39 +315,48 @@ public class AcknowledgementsIT {
         Assertions.assertFalse(list2.containsKey(deletedAck.getId()), "list2 should not contain the deleted ack");
     }
 
-    /*
-     * Max Ack value is set to 2, so the Ack list should be full after
-     * getCurrentAckValue() is called 3 times. getCurrentAckValue is called 4 times
-     * here, so ServerIsBusyException is expected to happen.
+    /**
+     * Max Ack value is set to 2, so the Ack list should be full after getCurrentAckValue() is called 3 times.
+     * getCurrentAckValue is called 4 times here, so ServerIsBusyException is expected to happen.
      */
     @Test
-    public void maxAckValueTest() {
-        final Configuration configuration1 = new Configuration();
-        configuration1.setMaxAckValue(2);
-        final Acknowledgements acknowledgements1 = new Acknowledgements(configuration1);
+    void maxAckValueTest() {
+        final String authToken1 = "AUTH_TOKEN_11111";
+        final String channel1 = "CHANNEL_11111";
 
-        final int ackId1 = acknowledgements1.getCurrentAckValue(this.authToken1, this.channel1);
+        final Configuration configuration = new Configuration(
+                "localhost",
+                1234,
+                2, // maxAckValue
+                20000,
+                30000,
+                1000000,
+                1000000,
+                true
+        );
+        final Acknowledgements acknowledgements1 = new Acknowledgements(configuration);
+
+        final int ackId1 = acknowledgements1.getCurrentAckValue(authToken1, channel1);
         Assertions.assertEquals(0, ackId1);
-        acknowledgements1.incrementAckValue(this.authToken1, this.channel1);
-        acknowledgements1.addAck(this.authToken1, this.channel1, new Ack(ackId1, false));
+        acknowledgements1.incrementAckValue(authToken1, channel1);
+        acknowledgements1.addAck(authToken1, channel1, new Ack(ackId1, false));
 
-        final int ackId2 = acknowledgements1.getCurrentAckValue(this.authToken1, this.channel1);
+        final int ackId2 = acknowledgements1.getCurrentAckValue(authToken1, channel1);
         Assertions.assertEquals(1, ackId2);
-        acknowledgements1.incrementAckValue(this.authToken1, this.channel1);
-        acknowledgements1.addAck(this.authToken1, this.channel1, new Ack(ackId2, false));
+        acknowledgements1.incrementAckValue(authToken1, channel1);
+        acknowledgements1.addAck(authToken1, channel1, new Ack(ackId2, false));
 
-        final int ackId3 = acknowledgements1.getCurrentAckValue(this.authToken1, this.channel1);
+        final int ackId3 = acknowledgements1.getCurrentAckValue(authToken1, channel1);
         Assertions.assertEquals(2, ackId3);
-        acknowledgements1.incrementAckValue(this.authToken1, this.channel1);
-        acknowledgements1.addAck(this.authToken1, this.channel1, new Ack(ackId3, false));
+        acknowledgements1.incrementAckValue(authToken1, channel1);
+        acknowledgements1.addAck(authToken1, channel1, new Ack(ackId3, false));
 
-        final int ackId4 = acknowledgements1.getCurrentAckValue(this.authToken1, this.channel1);
+        final int ackId4 = acknowledgements1.getCurrentAckValue(authToken1, channel1);
         Assertions.assertEquals(0, ackId4);
 
         Assertions
                 .assertThrows(
-                        ServerIsBusyException.class,
-                        () -> acknowledgements1.incrementAckValue(this.authToken1, this.channel1)
+                        ServerIsBusyException.class, () -> acknowledgements1.incrementAckValue(authToken1, channel1)
                 );
     }
 }

--- a/src/test/java/com/teragrep/cfe_16/it/ConfigurationIT.java
+++ b/src/test/java/com/teragrep/cfe_16/it/ConfigurationIT.java
@@ -55,8 +55,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -67,10 +65,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
-public class ConfigurationIT {
+final class ConfigurationIT {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationIT.class);
-    private static final String hostname = "localhost";
     private static final Integer port = 1235;
     private static final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
     private static final AtomicLong openCount = new AtomicLong();
@@ -80,33 +76,31 @@ public class ConfigurationIT {
     private Configuration configuration;
 
     @BeforeAll
-    public static void init() {
+    static void init() {
         final TestServerFactory serverFactory = new TestServerFactory();
         server = Assertions.assertDoesNotThrow(() -> serverFactory.create(port, messageList, openCount, closeCount));
         server.run();
     }
 
     @AfterAll
-    public static void close() {
+    static void close() {
         Assertions.assertDoesNotThrow(() -> server.close());
     }
 
     @AfterEach
-    public void clear() {
+    void clear() {
         openCount.set(0);
         closeCount.set(0);
         messageList.clear();
     }
 
     @Test
-    public void instantiateConfigurationTest() {
+    void testConfigurationAutowiringValues() {
         final String expected = "Configuration{syslogHost=127.0.0.1, syslogPort=1235, maxAckValue=1000000, maxAckAge=20000, maxSessionAge=30000, "
                 + "maxChannels=1000000, pollTime=1000000, printTimes=true}";
-        LOGGER.debug(configuration.toString());
 
         assertEquals(expected, configuration.toString());
         assertEquals(0, messageList.size());
         assertEquals(1, openCount.get());
-        assertEquals(0, closeCount.get());
     }
 }

--- a/src/test/java/com/teragrep/cfe_16/it/ConfigurationIT.java
+++ b/src/test/java/com/teragrep/cfe_16/it/ConfigurationIT.java
@@ -102,5 +102,6 @@ final class ConfigurationIT {
         assertEquals(expected, configuration.toString());
         assertEquals(0, messageList.size());
         assertEquals(1, openCount.get());
+        assertEquals(0, closeCount.get());
     }
 }

--- a/src/test/java/com/teragrep/cfe_16/it/SendMultipleEventsIT.java
+++ b/src/test/java/com/teragrep/cfe_16/it/SendMultipleEventsIT.java
@@ -62,8 +62,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.*;
 import org.springframework.mock.web.MockHttpServletRequest;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.*;
 
 final class SendMultipleEventsIT {
@@ -100,7 +98,6 @@ final class SendMultipleEventsIT {
                 new TokenManager(),
                 relpConnection
         );
-        Assertions.assertEquals(1, openCount.intValue());
 
         final MockHttpServletRequest request1 = new MockHttpServletRequest();
         request1.addHeader("Authorization", "AUTH_TOKEN_11111");
@@ -108,32 +105,22 @@ final class SendMultipleEventsIT {
         final String eventInJson = "{\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", \"event\": {\"message\":\"Access log test message 1\"}} {\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", \"event\": {\"message\":\"Access log test message 2\"}}";
 
         final int NUMBER_OF_EVENTS_TO_BE_SENT = 100;
-        final List<CompletableFuture<Response>> futures = new ArrayList<>();
 
+        int count = 0;
         for (int i = 0; i < NUMBER_OF_EVENTS_TO_BE_SENT; i++) {
-            final CompletableFuture<Response> future = CompletableFuture
-                    .supplyAsync(() -> service.sendEvents(request1, channel1, eventInJson));
-            futures.add(future);
-        }
-        final List<Response> supposedResponses = new ArrayList<>();
-        for (int i = 0; i < NUMBER_OF_EVENTS_TO_BE_SENT; i++) {
+            final Response response = service.sendEvents(request1, channel1, eventInJson);
             final Response supposedResponse = new AcknowledgedJsonResponse("Success", i);
-            supposedResponses.add(supposedResponse);
-        }
-        int countFuture = 0;
-        for (final Future<Response> future : futures) {
-            final Response actualResponse = Assertions.assertDoesNotThrow(() -> future.get());
-            Assertions
-                    .assertTrue(supposedResponses.contains(actualResponse), "Service should return JSON object with fields 'text', 'code' and 'ackID' (ackID should be " + countFuture + ")");
-            countFuture++;
+            Assertions.assertEquals(supposedResponse, response);
+            count++;
         }
 
-        Assertions.assertEquals(NUMBER_OF_EVENTS_TO_BE_SENT, countFuture, "All futures have NOT been looped through");
+        Assertions.assertEquals(NUMBER_OF_EVENTS_TO_BE_SENT, count, "All loops weren't looped through");
 
         Assertions.assertEquals(NUMBER_OF_EVENTS_TO_BE_SENT * 2, messageList.size());
 
         Assertions.assertDoesNotThrow(relpConnection::close);
         Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, openCount.intValue());
         Assertions.assertEquals(1, closeCount.intValue());
     }
 }

--- a/src/test/java/com/teragrep/cfe_16/it/SendMultipleEventsIT.java
+++ b/src/test/java/com/teragrep/cfe_16/it/SendMultipleEventsIT.java
@@ -45,81 +45,68 @@
  */
 package com.teragrep.cfe_16.it;
 
+import com.teragrep.cfe_16.Acknowledgements;
+import com.teragrep.cfe_16.SessionManager;
+import com.teragrep.cfe_16.TokenManager;
+import com.teragrep.cfe_16.config.Configuration;
+import com.teragrep.cfe_16.connection.RelpConnection;
 import com.teragrep.cfe_16.response.AcknowledgedJsonResponse;
 import com.teragrep.cfe_16.response.Response;
 import com.teragrep.cfe_16.server.TestServer;
 import com.teragrep.cfe_16.server.TestServerFactory;
 import com.teragrep.cfe_16.service.HECService;
+import com.teragrep.cfe_16.service.HECServiceImpl;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.TestPropertySource;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.*;
 
-@TestPropertySource(properties = {
-        "syslog.server.host=127.0.0.1",
-        "syslog.server.port=1236",
-        "max.channels=1000000",
-        "max.ack.value=1000000",
-        "max.ack.age=20000",
-        "max.session.age=30000",
-        "poll.time=30000",
-        "server.print.times=true"
-})
-@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
-@SpringBootTest
-public class SendMultipleEventsIT {
-
-    private static final int SERVER_PORT = 1236;
-    private static final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
-    private static final AtomicLong openCount = new AtomicLong();
-    private static final AtomicLong closeCount = new AtomicLong();
-    private static TestServer server;
-    @Autowired
-    private HECService service;
-    private MockHttpServletRequest request1;
-    private String eventInJson;
-    private String channel1;
-
-    @BeforeAll
-    public static void init() {
-        final TestServerFactory serverFactory = new TestServerFactory();
-        server = Assertions
-                .assertDoesNotThrow(() -> serverFactory.create(SERVER_PORT, messageList, openCount, closeCount));
-        server.run();
-    }
-
-    @AfterAll
-    public static void close() {
-        Assertions.assertDoesNotThrow(() -> server.close());
-    }
-
-    @AfterEach
-    public void clear() {
-        openCount.set(0);
-        closeCount.set(0);
-        messageList.clear();
-    }
-
-    @BeforeEach
-    public void initEach() {
-
-        this.request1 = new MockHttpServletRequest();
-        this.request1.addHeader("Authorization", "AUTH_TOKEN_11111");
-        this.channel1 = "CHANNEL_11111";
-        this.eventInJson = "{\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", \"event\": {\"message\":\"Access log test message 1\"}} {\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", \"event\": {\"message\":\"Access log test message 2\"}}";
-
-    }
+final class SendMultipleEventsIT {
 
     @Test
-    public void sendEventsTest() {
+    void sendEventsTest() {
+        final int serverPort = 1236;
+        final TestServerFactory serverFactory = new TestServerFactory();
+        final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
+        final AtomicLong openCount = new AtomicLong();
+        final AtomicLong closeCount = new AtomicLong();
+
+        final TestServer server = Assertions
+                .assertDoesNotThrow(() -> serverFactory.create(serverPort, messageList, openCount, closeCount));
+
+        server.run();
+
+        final Configuration configuration = new Configuration(
+                "localhost",
+                serverPort,
+                1000000,
+                20000,
+                30000,
+                1000000,
+                1000000,
+                true
+        );
+        final RelpConnection relpConnection = new RelpConnection("localhost", serverPort);
+        Assertions
+                .assertTimeout(Duration.of(5, ChronoUnit.SECONDS), relpConnection::connect, "RelpConnection did not connect in 5 seconds");
+        final HECService service = new HECServiceImpl(
+                new Acknowledgements(configuration),
+                new SessionManager(configuration),
+                new TokenManager(),
+                relpConnection
+        );
+        Assertions.assertEquals(1, openCount.intValue());
+
+        final MockHttpServletRequest request1 = new MockHttpServletRequest();
+        request1.addHeader("Authorization", "AUTH_TOKEN_11111");
+        final String channel1 = "CHANNEL_11111";
+        final String eventInJson = "{\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", \"event\": {\"message\":\"Access log test message 1\"}} {\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", \"event\": {\"message\":\"Access log test message 2\"}}";
+
         final int NUMBER_OF_EVENTS_TO_BE_SENT = 100;
         final List<CompletableFuture<Response>> futures = new ArrayList<>();
 
@@ -144,5 +131,9 @@ public class SendMultipleEventsIT {
         Assertions.assertEquals(NUMBER_OF_EVENTS_TO_BE_SENT, countFuture, "All futures have NOT been looped through");
 
         Assertions.assertEquals(NUMBER_OF_EVENTS_TO_BE_SENT * 2, messageList.size());
+
+        Assertions.assertDoesNotThrow(relpConnection::close);
+        Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, closeCount.intValue());
     }
 }

--- a/src/test/java/com/teragrep/cfe_16/it/SendSingleEventIT.java
+++ b/src/test/java/com/teragrep/cfe_16/it/SendSingleEventIT.java
@@ -98,7 +98,6 @@ final class SendSingleEventIT {
                 new TokenManager(),
                 relpConnection
         );
-        Assertions.assertEquals(1, openCount.intValue());
 
         final MockHttpServletRequest request1 = new MockHttpServletRequest();
         request1.addHeader("Authorization", "AUTH_TOKEN_11111");
@@ -117,6 +116,7 @@ final class SendSingleEventIT {
 
         Assertions.assertDoesNotThrow(relpConnection::close);
         Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, openCount.intValue());
         Assertions.assertEquals(1, closeCount.intValue());
     }
 }

--- a/src/test/java/com/teragrep/cfe_16/it/SendSingleEventIT.java
+++ b/src/test/java/com/teragrep/cfe_16/it/SendSingleEventIT.java
@@ -45,88 +45,78 @@
  */
 package com.teragrep.cfe_16.it;
 
+import com.teragrep.cfe_16.Acknowledgements;
+import com.teragrep.cfe_16.SessionManager;
+import com.teragrep.cfe_16.TokenManager;
+import com.teragrep.cfe_16.config.Configuration;
+import com.teragrep.cfe_16.connection.RelpConnection;
 import com.teragrep.cfe_16.response.AcknowledgedJsonResponse;
 import com.teragrep.cfe_16.response.Response;
 import com.teragrep.cfe_16.server.TestServer;
 import com.teragrep.cfe_16.server.TestServerFactory;
 import com.teragrep.cfe_16.service.HECService;
+import com.teragrep.cfe_16.service.HECServiceImpl;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicLong;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.test.context.TestPropertySource;
 
-@TestPropertySource(properties = {
-        "syslog.server.host=127.0.0.1",
-        "syslog.server.port=1238",
-        "syslog.server.protocol=RELP",
-        "max.channels=1000000",
-        "max.ack.value=1000000",
-        "max.ack.age=20000",
-        "max.session.age=30000",
-        "poll.time=30000",
-        "spring.devtools.add-properties=false",
-        "server.print.times=true"
-})
-@SpringBootTest
-public class SendSingleEventIT {
+final class SendSingleEventIT {
 
-    private static final int SERVER_PORT = 1238;
-    private static final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
-    private static final AtomicLong openCount = new AtomicLong();
-    private static final AtomicLong closeCount = new AtomicLong();
-    private static TestServer server;
-    @Autowired
-    private HECService service;
-    private MockHttpServletRequest request1;
-    private String eventInJson;
-    private String channel1;
-
-    @BeforeAll
-    public static void init() {
+    @Test
+    void send1EventTest() {
+        final int serverPort = 1238;
         final TestServerFactory serverFactory = new TestServerFactory();
-        server = Assertions
-                .assertDoesNotThrow(() -> serverFactory.create(SERVER_PORT, messageList, openCount, closeCount));
+        final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
+        final AtomicLong openCount = new AtomicLong();
+        final AtomicLong closeCount = new AtomicLong();
+
+        final TestServer server = Assertions
+                .assertDoesNotThrow(() -> serverFactory.create(serverPort, messageList, openCount, closeCount));
+
         server.run();
-    }
 
-    @AfterAll
-    public static void close() {
-        Assertions.assertDoesNotThrow(() -> server.close());
-    }
+        final Configuration configuration = new Configuration(
+                "localhost",
+                serverPort,
+                1000000,
+                20000,
+                30000,
+                1000000,
+                1000000,
+                true
+        );
+        final RelpConnection relpConnection = new RelpConnection("localhost", serverPort);
+        Assertions
+                .assertTimeout(Duration.of(5, ChronoUnit.SECONDS), relpConnection::connect, "RelpConnection did not connect in 5 seconds");
+        final HECService service = new HECServiceImpl(
+                new Acknowledgements(configuration),
+                new SessionManager(configuration),
+                new TokenManager(),
+                relpConnection
+        );
+        Assertions.assertEquals(1, openCount.intValue());
 
-    @AfterEach
-    public void clear() {
-        openCount.set(0);
-        closeCount.set(0);
-        messageList.clear();
-    }
-
-    @BeforeEach
-    public void initEach() {
-        this.request1 = new MockHttpServletRequest();
-        this.request1.addHeader("Authorization", "AUTH_TOKEN_11111");
-        this.channel1 = "CHANNEL_11111";
-        this.eventInJson = "{\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", "
+        final MockHttpServletRequest request1 = new MockHttpServletRequest();
+        request1.addHeader("Authorization", "AUTH_TOKEN_11111");
+        final String channel1 = "CHANNEL_11111";
+        final String eventInJson = "{\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", "
                 + "\"event\": {\"message\":\"Access log test message 1\"}} "
                 + "{\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", \"event\": "
                 + "{\"message\":\"Access log test message 2\"}}";
-    }
 
-    @Test
-    public void send1EventTest() {
         final Response supposedResponse = new AcknowledgedJsonResponse("Success", 0);
         Assertions
                 .assertEquals(supposedResponse, service.sendEvents(request1, channel1, eventInJson), "Service should return JSON object with fields 'text', 'code' and 'ackID' (ackID " + "should be " + 0 + ")");
 
         Assertions
                 .assertEquals(2, messageList.size(), "Number of events received should match the number of sent ones");
+
+        Assertions.assertDoesNotThrow(relpConnection::close);
+        Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, closeCount.intValue());
     }
 }

--- a/src/test/java/com/teragrep/cfe_16/it/ServiceAndHECBatchIT.java
+++ b/src/test/java/com/teragrep/cfe_16/it/ServiceAndHECBatchIT.java
@@ -45,7 +45,15 @@
  */
 package com.teragrep.cfe_16.it;
 
+import com.teragrep.cfe_16.Acknowledgements;
+import com.teragrep.cfe_16.SessionManager;
+import com.teragrep.cfe_16.TokenManager;
+import com.teragrep.cfe_16.config.Configuration;
+import com.teragrep.cfe_16.connection.RelpConnection;
 import com.teragrep.cfe_16.response.AcknowledgementResponse;
+import com.teragrep.cfe_16.service.HECServiceImpl;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import com.teragrep.cfe_16.exceptionhandling.*;
@@ -59,117 +67,69 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.*;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
 import tools.jackson.databind.node.ObjectNode;
 
-/*
+/**
  * Tests the functionality of HECServiceImpl
  */
-
-@SpringBootTest
-@TestPropertySource(properties = {
-        "syslog.server.host=127.0.0.1",
-        "syslog.server.port=1603",
-        "syslog.server.protocol=RELP",
-        "max.channels=1000000",
-        "max.ack.value=1000000",
-        "max.ack.age=20000",
-        "max.session.age=30000",
-        "poll.time=30000",
-        "server.print.times=true"
-})
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-public class ServiceAndHECBatchIT {
-
-    private static final Integer port = 1603;
-    private static final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
-    private static final AtomicLong openCount = new AtomicLong();
-    private static final AtomicLong closeCount = new AtomicLong();
-    private static TestServer server;
-    @Autowired
-    private HECService service;
-    private MockHttpServletRequest request1;
-    private MockHttpServletRequest request2;
-    private MockHttpServletRequest request3;
-    private MockHttpServletRequest request4;
-    private MockHttpServletRequest request5;
-    private String eventInJson;
-    private String channel1;
-    private String channel2;
-    private String channel3;
-    private String authToken1;
-    private String authToken2;
-    private String authToken3;
-    private String authToken4;
-    private String ackRequest;
-    private ObjectMapper objectMapper;
-    private JsonNode ackRequestNode;
-
-    @BeforeAll
-    public static void init() {
-        final TestServerFactory serverFactory = new TestServerFactory();
-        server = Assertions.assertDoesNotThrow(() -> serverFactory.create(port, messageList, openCount, closeCount));
-        server.run();
-    }
-
-    @AfterAll
-    public static void close() {
-        Assertions.assertDoesNotThrow(() -> server.close());
-    }
-
-    @AfterEach
-    public void clear() {
-        openCount.set(0);
-        closeCount.set(0);
-        messageList.clear();
-    }
-
-    /*
-     * Opens a ServerSocket so that the sending an event won't produce an error. 4
-     * Mock requests are created. request2 will not have authorization token
-     * assigned to it. eventInJson variable is the body of the request as a string
-     * when sending an event and ackRequest is the body of the request when
-     * requesting Ack statuses.
-     */
-    @BeforeEach
-    public void initialize() {
-        objectMapper = new ObjectMapper();
-        request1 = new MockHttpServletRequest();
-        request2 = new MockHttpServletRequest();
-        request3 = new MockHttpServletRequest();
-        request4 = new MockHttpServletRequest();
-        request5 = new MockHttpServletRequest();
-
-        eventInJson = "{\"sourcetype\": \"mysourcetype\", \"event\": \"Hello, world!\", \"host\": \"localhost\", \"source\": \"mysource\", \"index\": \"myindex\"}";
-
-        channel1 = "CHANNEL_11111";
-        channel2 = "CHANNEL_22222";
-        channel3 = "CHANNEL_33333";
-
-        authToken1 = "AUTH_TOKEN_12223";
-        authToken2 = "AUTH_TOKEN_16664";
-        authToken3 = "AUTH_TOKEN_23667";
-        authToken4 = "AUTH_TOKEN_23249";
-
-        request1.addHeader("Authorization", authToken1);
-        request3.addHeader("Authorization", authToken2);
-        request4.addHeader("Authorization", authToken3);
-        request5.addHeader("Authorization", authToken4);
-
-        ackRequest = "{\"acks\": [1,3,4]}";
-
-        ackRequestNode = Assertions.assertDoesNotThrow(() -> objectMapper.readTree(ackRequest));
-    }
+final class ServiceAndHECBatchIT {
 
     /*
      * Tests the sendEvents() and getAcks() method of the service.
      */
     @Test
-    public void sendEventsAndGetAcksTest() {
+    void sendEventsAndGetAcksTest() {
+        final int serverPort = 1603;
+        final TestServerFactory serverFactory = new TestServerFactory();
+        final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
+        final AtomicLong openCount = new AtomicLong();
+        final AtomicLong closeCount = new AtomicLong();
+
+        final TestServer server = Assertions
+                .assertDoesNotThrow(() -> serverFactory.create(serverPort, messageList, openCount, closeCount));
+
+        server.run();
+
+        final Configuration configuration = new Configuration(
+                "localhost",
+                serverPort,
+                1000000,
+                20000,
+                30000,
+                1000000,
+                1000000,
+                true
+        );
+        final RelpConnection relpConnection = new RelpConnection("localhost", serverPort);
+        Assertions
+                .assertTimeout(Duration.of(5, ChronoUnit.SECONDS), relpConnection::connect, "RelpConnection did not connect in 5 seconds");
+        final HECService service = new HECServiceImpl(
+                new Acknowledgements(configuration),
+                new SessionManager(configuration),
+                new TokenManager(),
+                relpConnection
+        );
+        Assertions.assertEquals(1, openCount.intValue());
+
+        final String authToken1 = "AUTH_TOKEN_12223";
+        final String authToken2 = "AUTH_TOKEN_16664";
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final MockHttpServletRequest request1 = new MockHttpServletRequest();
+        request1.addHeader("Authorization", authToken1);
+        final MockHttpServletRequest request3 = new MockHttpServletRequest();
+        request3.addHeader("Authorization", authToken2);
+
+        final String eventInJson = "{\"sourcetype\": \"mysourcetype\", \"event\": \"Hello, world!\", \"host\": \"localhost\", \"source\": \"mysource\", \"index\": \"myindex\"}";
+
+        final String channel2 = "CHANNEL_22222";
+        final String channel3 = "CHANNEL_33333";
+
+        final String ackRequest = "{\"acks\": [1,3,4]}";
+
+        final JsonNode ackRequestNode = Assertions.assertDoesNotThrow(() -> objectMapper.readTree(ackRequest));
+
         final Response supposedResponse1 = new AcknowledgedJsonResponse("Success", 0);
         final Response returnedResponse1 = service.sendEvents(request1, channel3, eventInJson);
         Assertions
@@ -214,6 +174,10 @@ public class ServiceAndHECBatchIT {
 
         Assertions
                 .assertEquals(supposedResponse5, returnedResponse5, "JSON object should be returned with ack statuses.");
+
+        Assertions.assertDoesNotThrow(relpConnection::close);
+        Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, closeCount.intValue());
     }
 
     /*
@@ -221,10 +185,50 @@ public class ServiceAndHECBatchIT {
      * AuthenticationTokenMissingException is expected to happen.
      */
     @Test
-    public void sendEventsWithoutAuthTokenTest() {
+    void sendEventsWithoutAuthTokenTest() {
+        final int serverPort = 1603;
+        final TestServerFactory serverFactory = new TestServerFactory();
+        final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
+        final AtomicLong openCount = new AtomicLong();
+        final AtomicLong closeCount = new AtomicLong();
+
+        final TestServer server = Assertions
+                .assertDoesNotThrow(() -> serverFactory.create(serverPort, messageList, openCount, closeCount));
+
+        server.run();
+
+        final Configuration configuration = new Configuration(
+                "localhost",
+                serverPort,
+                1000000,
+                20000,
+                30000,
+                1000000,
+                1000000,
+                true
+        );
+        final RelpConnection relpConnection = new RelpConnection("localhost", serverPort);
+        Assertions
+                .assertTimeout(Duration.of(5, ChronoUnit.SECONDS), relpConnection::connect, "RelpConnection did not connect in 5 seconds");
+        final HECService service = new HECServiceImpl(
+                new Acknowledgements(configuration),
+                new SessionManager(configuration),
+                new TokenManager(),
+                relpConnection
+        );
+        Assertions.assertEquals(1, openCount.intValue());
+
+        final MockHttpServletRequest request2 = new MockHttpServletRequest();
+        final String eventInJson = "{\"sourcetype\": \"mysourcetype\", \"event\": \"Hello, world!\", \"host\": \"localhost\", \"source\": \"mysource\", \"index\": \"myindex\"}";
+        final String channel1 = "CHANNEL_11111";
+
         Assertions.assertThrows(AuthenticationTokenMissingException.class, () -> {
             service.sendEvents(request2, eventInJson, channel1);
         });
+
+        Assertions.assertDoesNotThrow(relpConnection::close);
+        Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, closeCount.intValue());
     }
 
     /*
@@ -232,13 +236,55 @@ public class ServiceAndHECBatchIT {
      * returned.
      */
     @Test
-    public void sendEventsWithoutChannelTest() {
+    void sendEventsWithoutChannelTest() {
+        final int serverPort = 1603;
+        final TestServerFactory serverFactory = new TestServerFactory();
+        final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
+        final AtomicLong openCount = new AtomicLong();
+        final AtomicLong closeCount = new AtomicLong();
+
+        final TestServer server = Assertions
+                .assertDoesNotThrow(() -> serverFactory.create(serverPort, messageList, openCount, closeCount));
+
+        server.run();
+
+        final Configuration configuration = new Configuration(
+                "localhost",
+                serverPort,
+                1000000,
+                20000,
+                30000,
+                1000000,
+                1000000,
+                true
+        );
+        final RelpConnection relpConnection = new RelpConnection("localhost", serverPort);
+        Assertions
+                .assertTimeout(Duration.of(5, ChronoUnit.SECONDS), relpConnection::connect, "RelpConnection did not connect in 5 seconds");
+        final HECService service = new HECServiceImpl(
+                new Acknowledgements(configuration),
+                new SessionManager(configuration),
+                new TokenManager(),
+                relpConnection
+        );
+        Assertions.assertEquals(1, openCount.intValue());
+
+        final MockHttpServletRequest request1 = new MockHttpServletRequest();
+
+        final String eventInJson = "{\"sourcetype\": \"mysourcetype\", \"event\": \"Hello, world!\", \"host\": \"localhost\", \"source\": \"mysource\", \"index\": \"myindex\"}";
+        final String authToken1 = "AUTH_TOKEN_12223";
+        request1.addHeader("Authorization", authToken1);
+
         final Response supposedResponse = new JsonResponse("Success");
         final Response response = service.sendEvents(request1, null, eventInJson);
         Assertions
                 .assertEquals(
                         supposedResponse, response, "Service should return JSON object with fields 'text' and 'code'"
                 );
+
+        Assertions.assertDoesNotThrow(relpConnection::close);
+        Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, closeCount.intValue());
     }
 
     /*
@@ -246,10 +292,53 @@ public class ServiceAndHECBatchIT {
      * this case ChannelNotProvidedException is expected to happen.
      */
     @Test
-    public void getAcksWithoutChannel() {
+    void getAcksWithoutChannel() {
+        final int serverPort = 1603;
+        final TestServerFactory serverFactory = new TestServerFactory();
+        final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
+        final AtomicLong openCount = new AtomicLong();
+        final AtomicLong closeCount = new AtomicLong();
+
+        final TestServer server = Assertions
+                .assertDoesNotThrow(() -> serverFactory.create(serverPort, messageList, openCount, closeCount));
+
+        server.run();
+
+        final Configuration configuration = new Configuration(
+                "localhost",
+                serverPort,
+                1000000,
+                20000,
+                30000,
+                1000000,
+                1000000,
+                true
+        );
+        final RelpConnection relpConnection = new RelpConnection("localhost", serverPort);
+        Assertions
+                .assertTimeout(Duration.of(5, ChronoUnit.SECONDS), relpConnection::connect, "RelpConnection did not connect in 5 seconds");
+        final HECService service = new HECServiceImpl(
+                new Acknowledgements(configuration),
+                new SessionManager(configuration),
+                new TokenManager(),
+                relpConnection
+        );
+        Assertions.assertEquals(1, openCount.intValue());
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final MockHttpServletRequest request1 = new MockHttpServletRequest();
+        final String authToken1 = "AUTH_TOKEN_12223";
+        request1.addHeader("Authorization", authToken1);
+        final String ackRequest = "{\"acks\": [1,3,4]}";
+        final JsonNode ackRequestNode = Assertions.assertDoesNotThrow(() -> objectMapper.readTree(ackRequest));
+
         Assertions.assertThrows(ChannelNotProvidedException.class, () -> {
             service.getAcks(request1, null, ackRequestNode);
         });
+
+        Assertions.assertDoesNotThrow(relpConnection::close);
+        Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, closeCount.intValue());
     }
 
     /*
@@ -258,10 +347,52 @@ public class ServiceAndHECBatchIT {
      * happen.
      */
     @Test
-    public void getAcksWithoutAuthTokenTest() {
+    void getAcksWithoutAuthTokenTest() {
+        final int serverPort = 1603;
+        final TestServerFactory serverFactory = new TestServerFactory();
+        final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
+        final AtomicLong openCount = new AtomicLong();
+        final AtomicLong closeCount = new AtomicLong();
+
+        final TestServer server = Assertions
+                .assertDoesNotThrow(() -> serverFactory.create(serverPort, messageList, openCount, closeCount));
+
+        server.run();
+
+        final Configuration configuration = new Configuration(
+                "localhost",
+                serverPort,
+                1000000,
+                20000,
+                30000,
+                1000000,
+                1000000,
+                true
+        );
+        final RelpConnection relpConnection = new RelpConnection("localhost", serverPort);
+        Assertions
+                .assertTimeout(Duration.of(5, ChronoUnit.SECONDS), relpConnection::connect, "RelpConnection did not connect in 5 seconds");
+        final HECService service = new HECServiceImpl(
+                new Acknowledgements(configuration),
+                new SessionManager(configuration),
+                new TokenManager(),
+                relpConnection
+        );
+        Assertions.assertEquals(1, openCount.intValue());
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final MockHttpServletRequest request2 = new MockHttpServletRequest();
+        final String channel1 = "CHANNEL_11111";
+        final String ackRequest = "{\"acks\": [1,3,4]}";
+        final JsonNode ackRequestNode = Assertions.assertDoesNotThrow(() -> objectMapper.readTree(ackRequest));
+
         Assertions.assertThrows(AuthenticationTokenMissingException.class, () -> {
             service.getAcks(request2, channel1, ackRequestNode);
         });
+
+        Assertions.assertDoesNotThrow(relpConnection::close);
+        Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, closeCount.intValue());
     }
 
     /*
@@ -269,10 +400,54 @@ public class ServiceAndHECBatchIT {
      * send events. In this case SessionNotFoundException is expected to happen.
      */
     @Test
-    public void getAcksWithUnusedAuthToken() {
+    void getAcksWithUnusedAuthToken() {
+        final int serverPort = 1603;
+        final TestServerFactory serverFactory = new TestServerFactory();
+        final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
+        final AtomicLong openCount = new AtomicLong();
+        final AtomicLong closeCount = new AtomicLong();
+
+        final TestServer server = Assertions
+                .assertDoesNotThrow(() -> serverFactory.create(serverPort, messageList, openCount, closeCount));
+
+        server.run();
+
+        final Configuration configuration = new Configuration(
+                "localhost",
+                serverPort,
+                1000000,
+                20000,
+                30000,
+                1000000,
+                1000000,
+                true
+        );
+        final RelpConnection relpConnection = new RelpConnection("localhost", serverPort);
+        Assertions
+                .assertTimeout(Duration.of(5, ChronoUnit.SECONDS), relpConnection::connect, "RelpConnection did not connect in 5 seconds");
+        final HECService service = new HECServiceImpl(
+                new Acknowledgements(configuration),
+                new SessionManager(configuration),
+                new TokenManager(),
+                relpConnection
+        );
+        Assertions.assertEquals(1, openCount.intValue());
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final MockHttpServletRequest request4 = new MockHttpServletRequest();
+        final String channel1 = "CHANNEL_11111";
+        final String authToken3 = "AUTH_TOKEN_23667";
+        request4.addHeader("Authorization", authToken3);
+        final String ackRequest = "{\"acks\": [1,3,4]}";
+        final JsonNode ackRequestNode = Assertions.assertDoesNotThrow(() -> objectMapper.readTree(ackRequest));
+
         Assertions.assertThrows(SessionNotFoundException.class, () -> {
             service.getAcks(request4, channel1, ackRequestNode);
         });
+
+        Assertions.assertDoesNotThrow(relpConnection::close);
+        Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, closeCount.intValue());
     }
 
     /*
@@ -280,11 +455,57 @@ public class ServiceAndHECBatchIT {
      * session. In this case ChannelNotFoundException is expected to happen.
      */
     @Test
-    public void getAcksWithUnusedChannel() {
+    void getAcksWithUnusedChannel() {
+        final int serverPort = 1603;
+        final TestServerFactory serverFactory = new TestServerFactory();
+        final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
+        final AtomicLong openCount = new AtomicLong();
+        final AtomicLong closeCount = new AtomicLong();
+
+        final TestServer server = Assertions
+                .assertDoesNotThrow(() -> serverFactory.create(serverPort, messageList, openCount, closeCount));
+
+        server.run();
+
+        final Configuration configuration = new Configuration(
+                "localhost",
+                serverPort,
+                1000000,
+                20000,
+                30000,
+                1000000,
+                1000000,
+                true
+        );
+        final RelpConnection relpConnection = new RelpConnection("localhost", serverPort);
+        Assertions
+                .assertTimeout(Duration.of(5, ChronoUnit.SECONDS), relpConnection::connect, "RelpConnection did not connect in 5 seconds");
+        final HECService service = new HECServiceImpl(
+                new Acknowledgements(configuration),
+                new SessionManager(configuration),
+                new TokenManager(),
+                relpConnection
+        );
+        Assertions.assertEquals(1, openCount.intValue());
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final MockHttpServletRequest request5 = new MockHttpServletRequest();
+        final String eventInJson = "{\"sourcetype\": \"mysourcetype\", \"event\": \"Hello, world!\", \"host\": \"localhost\", \"source\": \"mysource\", \"index\": \"myindex\"}";
+        final String channel1 = "CHANNEL_11111";
+        final String channel2 = "CHANNEL_22222";
+        final String authToken4 = "AUTH_TOKEN_23249";
+        request5.addHeader("Authorization", authToken4);
+        final String ackRequest = "{\"acks\": [1,3,4]}";
+        final JsonNode ackRequestNode = Assertions.assertDoesNotThrow(() -> objectMapper.readTree(ackRequest));
+
         Assertions.assertThrows(ChannelNotFoundException.class, () -> {
             service.sendEvents(request5, channel1, eventInJson);
             service.getAcks(request5, channel2, ackRequestNode);
         });
+
+        Assertions.assertDoesNotThrow(relpConnection::close);
+        Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, closeCount.intValue());
     }
 
     /*
@@ -292,12 +513,52 @@ public class ServiceAndHECBatchIT {
      * at once.
      */
     @Test
-    public void sendingMultipleEventsTest() {
-        String allEventsInJson = "{\"event\": \"Pony 1 has left the barn\", \"sourcetype\": \"mysourcetype\", \"time\": 1426279439}{\"event\": \"Pony 2 has left the barn\"}{\"event\": \"Pony 3 has left the barn\", \"sourcetype\": \"newsourcetype\"}{\"event\": \"Pony 4 has left the barn\"}";
+    void sendingMultipleEventsTest() {
+        final int serverPort = 1603;
+        final TestServerFactory serverFactory = new TestServerFactory();
+        final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
+        final AtomicLong openCount = new AtomicLong();
+        final AtomicLong closeCount = new AtomicLong();
+
+        final TestServer server = Assertions
+                .assertDoesNotThrow(() -> serverFactory.create(serverPort, messageList, openCount, closeCount));
+
+        server.run();
+
+        final Configuration configuration = new Configuration(
+                "localhost",
+                serverPort,
+                1000000,
+                20000,
+                30000,
+                1000000,
+                1000000,
+                true
+        );
+        final RelpConnection relpConnection = new RelpConnection("localhost", serverPort);
+        Assertions
+                .assertTimeout(Duration.of(5, ChronoUnit.SECONDS), relpConnection::connect, "RelpConnection did not connect in 5 seconds");
+        final HECService service = new HECServiceImpl(
+                new Acknowledgements(configuration),
+                new SessionManager(configuration),
+                new TokenManager(),
+                relpConnection
+        );
+        Assertions.assertEquals(1, openCount.intValue());
+
+        final MockHttpServletRequest request1 = new MockHttpServletRequest();
+        final String channel1 = "CHANNEL_11111";
+        final String authToken1 = "AUTH_TOKEN_12223";
+        request1.addHeader("Authorization", authToken1);
+
+        final String allEventsInJson = "{\"event\": \"Pony 1 has left the barn\", \"sourcetype\": \"mysourcetype\", \"time\": 1426279439}{\"event\": \"Pony 2 has left the barn\"}{\"event\": \"Pony 3 has left the barn\", \"sourcetype\": \"newsourcetype\"}{\"event\": \"Pony 4 has left the barn\"}";
         final Response supposedResponse = new AcknowledgedJsonResponse("Success", 0);
         Assertions
                 .assertEquals(supposedResponse, service.sendEvents(request1, channel1, allEventsInJson), "Should get a JSON with fields text, code and ackID");
 
+        Assertions.assertDoesNotThrow(relpConnection::close);
+        Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, closeCount.intValue());
     }
 
     /*
@@ -305,10 +566,50 @@ public class ServiceAndHECBatchIT {
      * sending multiple events at once.
      */
     @Test
-    public void sendingMultipleEventsWithDefaultChannelTest() {
-        String allEventsInJson = "{\"event\": \"Pony 1 has left the barn\", \"sourcetype\": \"mysourcetype\", \"time\": 1426279439}{\"event\": \"Pony 2 has left the barn\"}{\"event\": \"Pony 3 has left the barn\", \"sourcetype\": \"newsourcetype\"}{\"event\": \"Pony 4 has left the barn\"}";
+    void sendingMultipleEventsWithDefaultChannelTest() {
+        final int serverPort = 1603;
+        final TestServerFactory serverFactory = new TestServerFactory();
+        final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
+        final AtomicLong openCount = new AtomicLong();
+        final AtomicLong closeCount = new AtomicLong();
+
+        final TestServer server = Assertions
+                .assertDoesNotThrow(() -> serverFactory.create(serverPort, messageList, openCount, closeCount));
+
+        server.run();
+
+        final Configuration configuration = new Configuration(
+                "localhost",
+                serverPort,
+                1000000,
+                20000,
+                30000,
+                1000000,
+                1000000,
+                true
+        );
+        final RelpConnection relpConnection = new RelpConnection("localhost", serverPort);
+        Assertions
+                .assertTimeout(Duration.of(5, ChronoUnit.SECONDS), relpConnection::connect, "RelpConnection did not connect in 5 seconds");
+        final HECService service = new HECServiceImpl(
+                new Acknowledgements(configuration),
+                new SessionManager(configuration),
+                new TokenManager(),
+                relpConnection
+        );
+        Assertions.assertEquals(1, openCount.intValue());
+
+        final MockHttpServletRequest request1 = new MockHttpServletRequest();
+        final String authToken1 = "AUTH_TOKEN_12223";
+        request1.addHeader("Authorization", authToken1);
+
+        final String allEventsInJson = "{\"event\": \"Pony 1 has left the barn\", \"sourcetype\": \"mysourcetype\", \"time\": 1426279439}{\"event\": \"Pony 2 has left the barn\"}{\"event\": \"Pony 3 has left the barn\", \"sourcetype\": \"newsourcetype\"}{\"event\": \"Pony 4 has left the barn\"}";
         final Response supposedResponse = new JsonResponse("Success");
         Assertions
                 .assertEquals(supposedResponse, service.sendEvents(request1, null, allEventsInJson), "Should get a JSON with fields text, code and ackID");
+
+        Assertions.assertDoesNotThrow(relpConnection::close);
+        Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, closeCount.intValue());
     }
 }

--- a/src/test/java/com/teragrep/cfe_16/it/ServiceAndHECBatchIT.java
+++ b/src/test/java/com/teragrep/cfe_16/it/ServiceAndHECBatchIT.java
@@ -110,7 +110,6 @@ final class ServiceAndHECBatchIT {
                 new TokenManager(),
                 relpConnection
         );
-        Assertions.assertEquals(1, openCount.intValue());
 
         final String authToken1 = "AUTH_TOKEN_12223";
         final String authToken2 = "AUTH_TOKEN_16664";
@@ -177,6 +176,7 @@ final class ServiceAndHECBatchIT {
 
         Assertions.assertDoesNotThrow(relpConnection::close);
         Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, openCount.intValue());
         Assertions.assertEquals(1, closeCount.intValue());
     }
 
@@ -216,7 +216,6 @@ final class ServiceAndHECBatchIT {
                 new TokenManager(),
                 relpConnection
         );
-        Assertions.assertEquals(1, openCount.intValue());
 
         final MockHttpServletRequest request2 = new MockHttpServletRequest();
         final String eventInJson = "{\"sourcetype\": \"mysourcetype\", \"event\": \"Hello, world!\", \"host\": \"localhost\", \"source\": \"mysource\", \"index\": \"myindex\"}";
@@ -228,6 +227,7 @@ final class ServiceAndHECBatchIT {
 
         Assertions.assertDoesNotThrow(relpConnection::close);
         Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, openCount.intValue());
         Assertions.assertEquals(1, closeCount.intValue());
     }
 
@@ -267,7 +267,6 @@ final class ServiceAndHECBatchIT {
                 new TokenManager(),
                 relpConnection
         );
-        Assertions.assertEquals(1, openCount.intValue());
 
         final MockHttpServletRequest request1 = new MockHttpServletRequest();
 
@@ -284,6 +283,7 @@ final class ServiceAndHECBatchIT {
 
         Assertions.assertDoesNotThrow(relpConnection::close);
         Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, openCount.intValue());
         Assertions.assertEquals(1, closeCount.intValue());
     }
 
@@ -323,7 +323,6 @@ final class ServiceAndHECBatchIT {
                 new TokenManager(),
                 relpConnection
         );
-        Assertions.assertEquals(1, openCount.intValue());
 
         final ObjectMapper objectMapper = new ObjectMapper();
         final MockHttpServletRequest request1 = new MockHttpServletRequest();
@@ -338,6 +337,7 @@ final class ServiceAndHECBatchIT {
 
         Assertions.assertDoesNotThrow(relpConnection::close);
         Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, openCount.intValue());
         Assertions.assertEquals(1, closeCount.intValue());
     }
 
@@ -378,7 +378,6 @@ final class ServiceAndHECBatchIT {
                 new TokenManager(),
                 relpConnection
         );
-        Assertions.assertEquals(1, openCount.intValue());
 
         final ObjectMapper objectMapper = new ObjectMapper();
         final MockHttpServletRequest request2 = new MockHttpServletRequest();
@@ -392,6 +391,7 @@ final class ServiceAndHECBatchIT {
 
         Assertions.assertDoesNotThrow(relpConnection::close);
         Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, openCount.intValue());
         Assertions.assertEquals(1, closeCount.intValue());
     }
 
@@ -431,7 +431,6 @@ final class ServiceAndHECBatchIT {
                 new TokenManager(),
                 relpConnection
         );
-        Assertions.assertEquals(1, openCount.intValue());
 
         final ObjectMapper objectMapper = new ObjectMapper();
         final MockHttpServletRequest request4 = new MockHttpServletRequest();
@@ -447,6 +446,7 @@ final class ServiceAndHECBatchIT {
 
         Assertions.assertDoesNotThrow(relpConnection::close);
         Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, openCount.intValue());
         Assertions.assertEquals(1, closeCount.intValue());
     }
 
@@ -486,7 +486,6 @@ final class ServiceAndHECBatchIT {
                 new TokenManager(),
                 relpConnection
         );
-        Assertions.assertEquals(1, openCount.intValue());
 
         final ObjectMapper objectMapper = new ObjectMapper();
         final MockHttpServletRequest request5 = new MockHttpServletRequest();
@@ -505,6 +504,7 @@ final class ServiceAndHECBatchIT {
 
         Assertions.assertDoesNotThrow(relpConnection::close);
         Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, openCount.intValue());
         Assertions.assertEquals(1, closeCount.intValue());
     }
 
@@ -544,7 +544,6 @@ final class ServiceAndHECBatchIT {
                 new TokenManager(),
                 relpConnection
         );
-        Assertions.assertEquals(1, openCount.intValue());
 
         final MockHttpServletRequest request1 = new MockHttpServletRequest();
         final String channel1 = "CHANNEL_11111";
@@ -558,6 +557,7 @@ final class ServiceAndHECBatchIT {
 
         Assertions.assertDoesNotThrow(relpConnection::close);
         Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, openCount.intValue());
         Assertions.assertEquals(1, closeCount.intValue());
     }
 
@@ -597,7 +597,6 @@ final class ServiceAndHECBatchIT {
                 new TokenManager(),
                 relpConnection
         );
-        Assertions.assertEquals(1, openCount.intValue());
 
         final MockHttpServletRequest request1 = new MockHttpServletRequest();
         final String authToken1 = "AUTH_TOKEN_12223";
@@ -610,6 +609,7 @@ final class ServiceAndHECBatchIT {
 
         Assertions.assertDoesNotThrow(relpConnection::close);
         Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, openCount.intValue());
         Assertions.assertEquals(1, closeCount.intValue());
     }
 }

--- a/src/test/java/com/teragrep/cfe_16/rest/HECRestControllerTest.java
+++ b/src/test/java/com/teragrep/cfe_16/rest/HECRestControllerTest.java
@@ -45,76 +45,60 @@
  */
 package com.teragrep.cfe_16.rest;
 
+import com.teragrep.cfe_16.Acknowledgements;
+import com.teragrep.cfe_16.SessionManager;
+import com.teragrep.cfe_16.TokenManager;
+import com.teragrep.cfe_16.config.Configuration;
+import com.teragrep.cfe_16.connection.RelpConnection;
 import com.teragrep.cfe_16.response.AcknowledgedJsonResponse;
 import com.teragrep.cfe_16.response.JsonResponse;
 import com.teragrep.cfe_16.server.TestServer;
 import com.teragrep.cfe_16.server.TestServerFactory;
+import com.teragrep.cfe_16.service.HECService;
+import com.teragrep.cfe_16.service.HECServiceImpl;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicLong;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import tools.jackson.databind.JsonNode;
 
-@TestPropertySource(properties = {
-        "syslog.server.host=127.0.0.1",
-        "syslog.server.port=1248",
-        "syslog.server.protocol=RELP",
-        "max.channels=1000000",
-        "max.ack.value=1000000",
-        "max.ack.age=20000",
-        "max.session.age=30000",
-        "poll.time=30000",
-        "spring.devtools.add-properties=false",
-        "server.print.times=true"
-})
-@SpringBootTest
-@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
-class HECRestControllerTest {
-
-    private static final int SERVER_PORT = 1248;
-    private static final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
-    private static final AtomicLong openCount = new AtomicLong();
-    private static final AtomicLong closeCount = new AtomicLong();
-    private static TestServer server;
-    @Autowired
-    private HECRestController hecRestController;
-
-    @BeforeAll
-    static void init() {
-        final TestServerFactory serverFactory = new TestServerFactory();
-        server = Assertions
-                .assertDoesNotThrow(() -> serverFactory.create(SERVER_PORT, messageList, openCount, closeCount));
-        server.run();
-    }
-
-    @AfterAll
-    static void cleanup() {
-        Assertions.assertDoesNotThrow(() -> server.close());
-    }
-
-    @AfterEach
-    void clear() {
-        openCount.set(0);
-        closeCount.set(0);
-        messageList.clear();
-    }
+final class HECRestControllerTest {
 
     @Test
     @DisplayName("test JSON sendEvents endpoint with channel present")
     void testJsonSendEventsEndpointWithChannelPresent() {
+        final int serverPort = 1248;
+        final TestServerFactory serverFactory = new TestServerFactory();
+        final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
+        final AtomicLong openCount = new AtomicLong();
+        final AtomicLong closeCount = new AtomicLong();
+
+        final TestServer server = Assertions
+                .assertDoesNotThrow(() -> serverFactory.create(serverPort, messageList, openCount, closeCount));
+
+        server.run();
+
+        final Configuration configuration = new Configuration();
+        final RelpConnection relpConnection = new RelpConnection("localhost", serverPort);
+        Assertions
+                .assertTimeout(Duration.of(5, ChronoUnit.SECONDS), relpConnection::connect, "RelpConnection did not connect in 5 seconds");
+        final HECService service = new HECServiceImpl(
+                new Acknowledgements(configuration),
+                new SessionManager(configuration),
+                new TokenManager(),
+                relpConnection
+        );
+        Assertions.assertEquals(1, openCount.intValue());
+
+        final HECRestController hecRestController = new HECRestController(service, configuration);
+
         final MockHttpServletRequest request1 = new MockHttpServletRequest();
         request1.addHeader("Authorization", "AUTH_TOKEN_11111");
         final String channel1 = "CHANNEL_11111";
@@ -124,16 +108,45 @@ class HECRestControllerTest {
                 + "{\"message\":\"Access log test message 2\"}}";
 
         final ResponseEntity<JsonNode> responseEntity = Assertions
-                .assertDoesNotThrow(() -> this.hecRestController.sendEvents(request1, eventInJson, channel1));
+                .assertDoesNotThrow(() -> hecRestController.sendEvents(request1, eventInJson, channel1));
         final AcknowledgedJsonResponse expectedResponse = new AcknowledgedJsonResponse("Success", 0);
         final ResponseEntity<JsonNode> expectedResponseEntity = expectedResponse.asJsonNodeResponseEntity();
 
         Assertions.assertEquals(expectedResponseEntity, responseEntity);
+
+        Assertions.assertDoesNotThrow(relpConnection::close);
+        Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, closeCount.intValue());
     }
 
     @Test
     @DisplayName("test JSON sendEvents endpoint without channel present")
     void testJsonSendEventsEndpointWithoutChannelPresent() {
+        final int serverPort = 1248;
+        final TestServerFactory serverFactory = new TestServerFactory();
+        final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
+        final AtomicLong openCount = new AtomicLong();
+        final AtomicLong closeCount = new AtomicLong();
+
+        final TestServer server = Assertions
+                .assertDoesNotThrow(() -> serverFactory.create(serverPort, messageList, openCount, closeCount));
+
+        server.run();
+
+        final Configuration configuration = new Configuration();
+        final RelpConnection relpConnection = new RelpConnection("localhost", serverPort);
+        Assertions
+                .assertTimeout(Duration.of(5, ChronoUnit.SECONDS), relpConnection::connect, "RelpConnection did not connect in 5 seconds");
+        final HECService service = new HECServiceImpl(
+                new Acknowledgements(configuration),
+                new SessionManager(configuration),
+                new TokenManager(),
+                relpConnection
+        );
+        Assertions.assertEquals(1, openCount.intValue());
+
+        final HECRestController hecRestController = new HECRestController(service, configuration);
+
         final MockHttpServletRequest request1 = new MockHttpServletRequest();
         request1.addHeader("Authorization", "AUTH_TOKEN_11111");
         final String eventInJson = "{\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", "
@@ -142,16 +155,45 @@ class HECRestControllerTest {
                 + "{\"message\":\"Access log test message 2\"}}";
 
         final ResponseEntity<JsonNode> responseEntity = Assertions
-                .assertDoesNotThrow(() -> this.hecRestController.sendEvents(request1, eventInJson, null));
+                .assertDoesNotThrow(() -> hecRestController.sendEvents(request1, eventInJson, null));
         final JsonResponse expectedResponse = new JsonResponse("Success");
         final ResponseEntity<JsonNode> expectedResponseEntity = expectedResponse.asJsonNodeResponseEntity();
 
         Assertions.assertEquals(expectedResponseEntity, responseEntity);
+
+        Assertions.assertDoesNotThrow(relpConnection::close);
+        Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, closeCount.intValue());
     }
 
     @Test
     @DisplayName("test multiValueMap sendEvents endpoint with channel present")
     void testMultiValueMapSendEventsEndpointWithChannelPresent() {
+        final int serverPort = 1248;
+        final TestServerFactory serverFactory = new TestServerFactory();
+        final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
+        final AtomicLong openCount = new AtomicLong();
+        final AtomicLong closeCount = new AtomicLong();
+
+        final TestServer server = Assertions
+                .assertDoesNotThrow(() -> serverFactory.create(serverPort, messageList, openCount, closeCount));
+
+        server.run();
+
+        final Configuration configuration = new Configuration();
+        final RelpConnection relpConnection = new RelpConnection("localhost", serverPort);
+        Assertions
+                .assertTimeout(Duration.of(5, ChronoUnit.SECONDS), relpConnection::connect, "RelpConnection did not connect in 5 seconds");
+        final HECService service = new HECServiceImpl(
+                new Acknowledgements(configuration),
+                new SessionManager(configuration),
+                new TokenManager(),
+                relpConnection
+        );
+        Assertions.assertEquals(1, openCount.intValue());
+
+        final HECRestController hecRestController = new HECRestController(service, configuration);
+
         final MockHttpServletRequest request1 = new MockHttpServletRequest();
         request1.addHeader("Authorization", "AUTH_TOKEN_11111");
         final String channel1 = "CHANNEL_11111";
@@ -165,16 +207,45 @@ class HECRestControllerTest {
         multiValueMap.add(eventInJson, null);
 
         final ResponseEntity<JsonNode> responseEntity = Assertions
-                .assertDoesNotThrow(() -> this.hecRestController.sendEvents(request1, multiValueMap, channel1));
+                .assertDoesNotThrow(() -> hecRestController.sendEvents(request1, multiValueMap, channel1));
         final AcknowledgedJsonResponse expectedResponse = new AcknowledgedJsonResponse("Success", 0);
         final ResponseEntity<JsonNode> expectedResponseEntity = expectedResponse.asJsonNodeResponseEntity();
 
         Assertions.assertEquals(expectedResponseEntity, responseEntity);
+
+        Assertions.assertDoesNotThrow(relpConnection::close);
+        Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, closeCount.intValue());
     }
 
     @Test
     @DisplayName("test multiValueMap sendEvents endpoint without channel present")
     void testMultiValueMapSendEventsEndpointWithoutChannelPresent() {
+        final int serverPort = 1248;
+        final TestServerFactory serverFactory = new TestServerFactory();
+        final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
+        final AtomicLong openCount = new AtomicLong();
+        final AtomicLong closeCount = new AtomicLong();
+
+        final TestServer server = Assertions
+                .assertDoesNotThrow(() -> serverFactory.create(serverPort, messageList, openCount, closeCount));
+
+        server.run();
+
+        final Configuration configuration = new Configuration();
+        final RelpConnection relpConnection = new RelpConnection("localhost", serverPort);
+        Assertions
+                .assertTimeout(Duration.of(5, ChronoUnit.SECONDS), relpConnection::connect, "RelpConnection did not connect in 5 seconds");
+        final HECService service = new HECServiceImpl(
+                new Acknowledgements(configuration),
+                new SessionManager(configuration),
+                new TokenManager(),
+                relpConnection
+        );
+        Assertions.assertEquals(1, openCount.intValue());
+
+        final HECRestController hecRestController = new HECRestController(service, configuration);
+
         final MockHttpServletRequest request1 = new MockHttpServletRequest();
         request1.addHeader("Authorization", "AUTH_TOKEN_11111");
         // Send JSON without the outer object brackets
@@ -186,10 +257,14 @@ class HECRestControllerTest {
         multiValueMap.add(eventInJson, null);
 
         final ResponseEntity<JsonNode> responseEntity = Assertions
-                .assertDoesNotThrow(() -> this.hecRestController.sendEvents(request1, multiValueMap, null));
+                .assertDoesNotThrow(() -> hecRestController.sendEvents(request1, multiValueMap, null));
         final JsonResponse expectedResponse = new JsonResponse("Success");
         final ResponseEntity<JsonNode> expectedResponseEntity = expectedResponse.asJsonNodeResponseEntity();
 
         Assertions.assertEquals(expectedResponseEntity, responseEntity);
+
+        Assertions.assertDoesNotThrow(relpConnection::close);
+        Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, closeCount.intValue());
     }
 }

--- a/src/test/java/com/teragrep/cfe_16/rest/HECRestControllerTest.java
+++ b/src/test/java/com/teragrep/cfe_16/rest/HECRestControllerTest.java
@@ -95,7 +95,6 @@ final class HECRestControllerTest {
                 new TokenManager(),
                 relpConnection
         );
-        Assertions.assertEquals(1, openCount.intValue());
 
         final HECRestController hecRestController = new HECRestController(service, configuration);
 
@@ -116,6 +115,7 @@ final class HECRestControllerTest {
 
         Assertions.assertDoesNotThrow(relpConnection::close);
         Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, openCount.intValue());
         Assertions.assertEquals(1, closeCount.intValue());
     }
 
@@ -143,7 +143,6 @@ final class HECRestControllerTest {
                 new TokenManager(),
                 relpConnection
         );
-        Assertions.assertEquals(1, openCount.intValue());
 
         final HECRestController hecRestController = new HECRestController(service, configuration);
 
@@ -163,6 +162,7 @@ final class HECRestControllerTest {
 
         Assertions.assertDoesNotThrow(relpConnection::close);
         Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, openCount.intValue());
         Assertions.assertEquals(1, closeCount.intValue());
     }
 
@@ -190,7 +190,6 @@ final class HECRestControllerTest {
                 new TokenManager(),
                 relpConnection
         );
-        Assertions.assertEquals(1, openCount.intValue());
 
         final HECRestController hecRestController = new HECRestController(service, configuration);
 
@@ -215,6 +214,7 @@ final class HECRestControllerTest {
 
         Assertions.assertDoesNotThrow(relpConnection::close);
         Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, openCount.intValue());
         Assertions.assertEquals(1, closeCount.intValue());
     }
 
@@ -242,7 +242,6 @@ final class HECRestControllerTest {
                 new TokenManager(),
                 relpConnection
         );
-        Assertions.assertEquals(1, openCount.intValue());
 
         final HECRestController hecRestController = new HECRestController(service, configuration);
 
@@ -265,6 +264,7 @@ final class HECRestControllerTest {
 
         Assertions.assertDoesNotThrow(relpConnection::close);
         Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, openCount.intValue());
         Assertions.assertEquals(1, closeCount.intValue());
     }
 }

--- a/src/test/java/com/teragrep/cfe_16/service/HECServiceImplTest.java
+++ b/src/test/java/com/teragrep/cfe_16/service/HECServiceImplTest.java
@@ -45,71 +45,53 @@
  */
 package com.teragrep.cfe_16.service;
 
+import com.teragrep.cfe_16.Acknowledgements;
+import com.teragrep.cfe_16.SessionManager;
+import com.teragrep.cfe_16.TokenManager;
+import com.teragrep.cfe_16.config.Configuration;
+import com.teragrep.cfe_16.connection.RelpConnection;
 import com.teragrep.cfe_16.response.AcknowledgedJsonResponse;
 import com.teragrep.cfe_16.response.ExceptionJsonResponse;
 import com.teragrep.cfe_16.response.Response;
 import com.teragrep.cfe_16.server.TestServer;
 import com.teragrep.cfe_16.server.TestServerFactory;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicLong;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.test.context.TestPropertySource;
 
-@SpringBootTest
-@TestPropertySource(properties = {
-        "syslog.server.host=127.0.0.1",
-        "syslog.server.port=1239",
-        "syslog.server.protocol=RELP",
-        "max.channels=1000000",
-        "max.ack.value=1000000",
-        "max.ack.age=20000",
-        "max.session.age=30000",
-        "poll.time=30000",
-        "server.print.times=true"
-})
-class HECServiceImplTest {
-
-    private static final int SERVER_PORT = 1239;
-    private static final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
-    private static final AtomicLong openCount = new AtomicLong();
-    private static final AtomicLong closeCount = new AtomicLong();
-    private static TestServer server;
-    @Autowired
-    private HECService service;
-
-    @BeforeAll
-    public static void init() {
-        final TestServerFactory serverFactory = new TestServerFactory();
-
-        server = Assertions
-                .assertDoesNotThrow(() -> serverFactory.create(SERVER_PORT, messageList, openCount, closeCount));
-
-        server.run();
-    }
-
-    @AfterAll
-    public static void close() {
-        Assertions.assertDoesNotThrow(() -> server.close());
-    }
-
-    @AfterEach
-    public void clear() {
-        openCount.set(0);
-        closeCount.set(0);
-        messageList.clear();
-    }
+final class HECServiceImplTest {
 
     @Test
     @DisplayName("test the sendEvents does not throw an exception when JSON is malformed")
     void testTheSendEventsDoesNotThrowAnExceptionWhenJsonIsMalformed() {
+        final int serverPort = 1239;
+        final TestServerFactory serverFactory = new TestServerFactory();
+        final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
+        final AtomicLong openCount = new AtomicLong();
+        final AtomicLong closeCount = new AtomicLong();
+
+        final TestServer server = Assertions
+                .assertDoesNotThrow(() -> serverFactory.create(serverPort, messageList, openCount, closeCount));
+
+        server.run();
+
+        final Configuration configuration = new Configuration();
+        final RelpConnection relpConnection = new RelpConnection("localhost", serverPort);
+        Assertions
+                .assertTimeout(Duration.of(5, ChronoUnit.SECONDS), relpConnection::connect, "RelpConnection did not connect in 5 seconds");
+        final HECService service = new HECServiceImpl(
+                new Acknowledgements(configuration),
+                new SessionManager(configuration),
+                new TokenManager(),
+                relpConnection
+        );
+        Assertions.assertEquals(1, openCount.intValue());
+
         final String allEventsInJson = "{\"sourcetype\": \"mysourcetype\", \"event\": {{{{}}}}";
         final MockHttpServletRequest request1 = new MockHttpServletRequest();
         request1.addHeader("Authorization", "AUTH_TOKEN_11111");
@@ -119,11 +101,38 @@ class HECServiceImplTest {
                 .assertDoesNotThrow(() -> service.sendEvents(request1, channel, allEventsInJson));
 
         Assertions.assertEquals(ExceptionJsonResponse.class, returnedResponse.getClass());
+
+        Assertions.assertDoesNotThrow(relpConnection::close);
+        Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, closeCount.intValue());
     }
 
     @Test
     @DisplayName("test the SendEvents when JSON is not malformed")
     void testTheSendEventsWhenJsonIsNotMalformed() {
+        final int serverPort = 1239;
+        final TestServerFactory serverFactory = new TestServerFactory();
+        final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
+        final AtomicLong openCount = new AtomicLong();
+        final AtomicLong closeCount = new AtomicLong();
+
+        final TestServer server = Assertions
+                .assertDoesNotThrow(() -> serverFactory.create(serverPort, messageList, openCount, closeCount));
+
+        server.run();
+
+        final Configuration configuration = new Configuration();
+        final RelpConnection relpConnection = new RelpConnection("localhost", serverPort);
+        Assertions
+                .assertTimeout(Duration.of(5, ChronoUnit.SECONDS), relpConnection::connect, "RelpConnection did not connect in 5 seconds");
+        final HECService service = new HECServiceImpl(
+                new Acknowledgements(configuration),
+                new SessionManager(configuration),
+                new TokenManager(),
+                relpConnection
+        );
+
+        Assertions.assertEquals(1, openCount.intValue());
         final String allEventsInJson = "{\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", \"event\": {\"message\":\"Access log test message 1\"}} {\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", \"event\": {\"message\":\"Access log test message 2\"}}";
         final MockHttpServletRequest request1 = new MockHttpServletRequest();
         request1.addHeader("Authorization", "AUTH_TOKEN_11111");
@@ -133,5 +142,9 @@ class HECServiceImplTest {
                 .assertDoesNotThrow(() -> service.sendEvents(request1, channel, allEventsInJson));
 
         Assertions.assertEquals(AcknowledgedJsonResponse.class, returnedResponse.getClass());
+
+        Assertions.assertDoesNotThrow(relpConnection::close);
+        Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, closeCount.intValue());
     }
 }

--- a/src/test/java/com/teragrep/cfe_16/service/HECServiceImplTest.java
+++ b/src/test/java/com/teragrep/cfe_16/service/HECServiceImplTest.java
@@ -90,7 +90,6 @@ final class HECServiceImplTest {
                 new TokenManager(),
                 relpConnection
         );
-        Assertions.assertEquals(1, openCount.intValue());
 
         final String allEventsInJson = "{\"sourcetype\": \"mysourcetype\", \"event\": {{{{}}}}";
         final MockHttpServletRequest request1 = new MockHttpServletRequest();
@@ -104,6 +103,7 @@ final class HECServiceImplTest {
 
         Assertions.assertDoesNotThrow(relpConnection::close);
         Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, openCount.intValue());
         Assertions.assertEquals(1, closeCount.intValue());
     }
 
@@ -132,7 +132,6 @@ final class HECServiceImplTest {
                 relpConnection
         );
 
-        Assertions.assertEquals(1, openCount.intValue());
         final String allEventsInJson = "{\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", \"event\": {\"message\":\"Access log test message 1\"}} {\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", \"event\": {\"message\":\"Access log test message 2\"}}";
         final MockHttpServletRequest request1 = new MockHttpServletRequest();
         request1.addHeader("Authorization", "AUTH_TOKEN_11111");
@@ -145,6 +144,7 @@ final class HECServiceImplTest {
 
         Assertions.assertDoesNotThrow(relpConnection::close);
         Assertions.assertDoesNotThrow(server::close);
+        Assertions.assertEquals(1, openCount.intValue());
         Assertions.assertEquals(1, closeCount.intValue());
     }
 }


### PR DESCRIPTION
Closes #31 

- Removes the annotated methods from test files
- Converts Spring Boot tests to normal unit tests

Configuration integration test is the only exception, where a SpringBootTest is testing the autowired values for the configuration
