### PR TITLE
Fix NPE thrown by MultiValueMap endpoints

### DIFF
--- a/src/main/java/com/teragrep/cfe_16/MultiValueMapRequest.java
+++ b/src/main/java/com/teragrep/cfe_16/MultiValueMapRequest.java
@@ -1,0 +1,94 @@
+/*
+ * HTTP Event Capture to RFC5424 CFE_16
+ * Copyright (C) 2021-2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.cfe_16;
+
+import java.util.Objects;
+import java.util.Set;
+import org.springframework.util.MultiValueMap;
+
+public final class MultiValueMapRequest {
+
+    private final MultiValueMap<String, String> multiValueMap;
+
+    public MultiValueMapRequest(final MultiValueMap<String, String> multiValueMap) {
+        this.multiValueMap = multiValueMap;
+    }
+
+    public String asCleanedJsonString() {
+        final String valueToReturn;
+        // Remove the channel, if it is present
+        multiValueMap.remove("channel");
+        final Set<String> keys = multiValueMap.keySet();
+
+        if (keys.size() == 1) {
+            valueToReturn = keys.iterator().next();
+        }
+        else {
+            final String multiValueMapString = multiValueMap.toString();
+            valueToReturn = this.removeFirstAndLastCharacters(multiValueMapString);
+        }
+
+        return valueToReturn;
+    }
+
+    private String removeFirstAndLastCharacters(final String string) {
+        return string.substring(1, string.length() - 1);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final MultiValueMapRequest that = (MultiValueMapRequest) o;
+        return Objects.equals(multiValueMap, that.multiValueMap);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(multiValueMap);
+    }
+}

--- a/src/main/java/com/teragrep/cfe_16/MultiValueMapRequest.java
+++ b/src/main/java/com/teragrep/cfe_16/MultiValueMapRequest.java
@@ -53,8 +53,7 @@ import org.springframework.util.MultiValueMap;
  * Cleans the request body so, that only the body of the request is left in the string. This is needed when calling the
  * endpoint that consumes MediaType.APPLICATION_FORM_URLENCODED_VALUE <b>The actual body needed is stored as a key, and
  * not a value for a key</b> Example of body sent as a parameter: {channel=[CHANNEL_11111], {"sourcetype":
- * "mysourcetype", "event": "Hello, world!"}=[]} Example of cleaned body returned by the cleanAckRequestBody():
- * {"sourcetype": "mysourcetype", "event": "Hello, world!"}
+ * "mysourcetype", "event": "Hello, world!"}=[]}
  */
 public final class MultiValueMapRequest {
 
@@ -64,6 +63,10 @@ public final class MultiValueMapRequest {
         this.multiValueMap = multiValueMap;
     }
 
+    /**
+     * @return Example of cleaned body: {"sourcetype": "mysourcetype", "event": "Hello, world!"}
+     * @throws IllegalStateException if the MultiValueMap contains more than one key after the channel has been removed
+     */
     public String asCleanedJsonString() throws IllegalStateException {
         final String valueToReturn;
         // Remove the channel, if it is present

--- a/src/main/java/com/teragrep/cfe_16/MultiValueMapRequest.java
+++ b/src/main/java/com/teragrep/cfe_16/MultiValueMapRequest.java
@@ -47,6 +47,7 @@ package com.teragrep.cfe_16;
 
 import java.util.Objects;
 import java.util.Set;
+import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 /**
@@ -69,9 +70,11 @@ public final class MultiValueMapRequest {
      */
     public String asCleanedJsonString() throws IllegalStateException {
         final String valueToReturn;
+        //
+        final MultiValueMap<String, String> copyOfMultiValueMap = new LinkedMultiValueMap<>(multiValueMap);
         // Remove the channel, if it is present
-        multiValueMap.remove("channel");
-        final Set<String> keys = multiValueMap.keySet();
+        copyOfMultiValueMap.remove("channel");
+        final Set<String> keys = copyOfMultiValueMap.keySet();
 
         // Check if the parameters contains more entries than expected from the request
         if (keys.size() != 1) {

--- a/src/main/java/com/teragrep/cfe_16/MultiValueMapRequest.java
+++ b/src/main/java/com/teragrep/cfe_16/MultiValueMapRequest.java
@@ -49,6 +49,13 @@ import java.util.Objects;
 import java.util.Set;
 import org.springframework.util.MultiValueMap;
 
+/**
+ * Cleans the request body so, that only the body of the request is left in the string. This is needed when calling the
+ * endpoint that consumes MediaType.APPLICATION_FORM_URLENCODED_VALUE <b>The actual body needed is stored as a key, and
+ * not a value for a key</b> Example of body sent as a parameter: {channel=[CHANNEL_11111], {"sourcetype":
+ * "mysourcetype", "event": "Hello, world!"}=[]} Example of cleaned body returned by the cleanAckRequestBody():
+ * {"sourcetype": "mysourcetype", "event": "Hello, world!"}
+ */
 public final class MultiValueMapRequest {
 
     private final MultiValueMap<String, String> multiValueMap;
@@ -57,25 +64,24 @@ public final class MultiValueMapRequest {
         this.multiValueMap = multiValueMap;
     }
 
-    public String asCleanedJsonString() {
+    public String asCleanedJsonString() throws IllegalStateException {
         final String valueToReturn;
         // Remove the channel, if it is present
         multiValueMap.remove("channel");
         final Set<String> keys = multiValueMap.keySet();
 
-        if (keys.size() == 1) {
-            valueToReturn = keys.iterator().next();
+        // Check if the parameters contains more entries than expected from the request
+        if (keys.size() != 1) {
+            throw new IllegalStateException(
+                    "application/x-www-form-urlencoded request contains more parameters than expected"
+            );
         }
         else {
-            final String multiValueMapString = multiValueMap.toString();
-            valueToReturn = this.removeFirstAndLastCharacters(multiValueMapString);
+            // Get the value of the first key
+            valueToReturn = keys.iterator().next();
         }
 
         return valueToReturn;
-    }
-
-    private String removeFirstAndLastCharacters(final String string) {
-        return string.substring(1, string.length() - 1);
     }
 
     @Override

--- a/src/main/java/com/teragrep/cfe_16/response/AcknowledgementResponse.java
+++ b/src/main/java/com/teragrep/cfe_16/response/AcknowledgementResponse.java
@@ -43,23 +43,47 @@
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
  */
-package com.teragrep.cfe_16;
+package com.teragrep.cfe_16.response;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import java.util.Objects;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 
-public class CleanRequestBodyTests {
+public final class AcknowledgementResponse implements Response {
 
-    @Test
-    public void testCleanRequestBodyNormal() {
-        String input = "{channel=[CHANNEL_11111], {\"sourcetype\": \"mysourcetype\", \"event\": \"Hello, world!\"}=[]}";
-        String channel = "CHANNEL_11111";
-        RequestBodyCleaner requestBodyCleaner = new RequestBodyCleaner();
-        String cleaned = requestBodyCleaner.cleanAckRequestBody(input, channel);
-        Assertions
-                .assertEquals(
-                        "{\"sourcetype\": \"mysourcetype\", \"event\": \"Hello, world!\"}", cleaned,
-                        "Did not clean channel properly"
-                );
+    /**
+     * This field is expected to be in a format provided by
+     * {@link com.teragrep.cfe_16.Acknowledgements#getRequestedAckStatuses(String, String, JsonNode)}
+     */
+    private final JsonNode acknowledgementsJsonNode;
+
+    public AcknowledgementResponse(final JsonNode acknowledgementsJsonNode) {
+        this.acknowledgementsJsonNode = acknowledgementsJsonNode;
+    }
+
+    @Override
+    public ResponseEntity<JsonNode> asJsonNodeResponseEntity() {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final ObjectNode jsonNode = objectMapper.createObjectNode();
+        jsonNode.set("acks", this.acknowledgementsJsonNode);
+
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(jsonNode);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final AcknowledgementResponse that = (AcknowledgementResponse) o;
+        return Objects.equals(acknowledgementsJsonNode, that.acknowledgementsJsonNode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(acknowledgementsJsonNode);
     }
 }

--- a/src/main/java/com/teragrep/cfe_16/rest/HECRestController.java
+++ b/src/main/java/com/teragrep/cfe_16/rest/HECRestController.java
@@ -45,9 +45,16 @@
  */
 package com.teragrep.cfe_16.rest;
 
+import com.teragrep.cfe_16.MultiValueMapRequest;
+import com.teragrep.cfe_16.bo.HeaderInfo;
+import com.teragrep.cfe_16.response.ExceptionEvent;
+import com.teragrep.cfe_16.response.ExceptionEventContext;
+import com.teragrep.cfe_16.response.ExceptionJsonResponse;
+import com.teragrep.cfe_16.response.JsonResponse;
+import java.util.UUID;
+import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
-import com.teragrep.cfe_16.RequestBodyCleaner;
 import com.teragrep.cfe_16.config.Configuration;
 import com.teragrep.cfe_16.response.Response;
 import com.teragrep.cfe_16.service.HECService;
@@ -70,12 +77,8 @@ public class HECRestController {
     private HECService service;
 
     @Autowired
-    private RequestBodyCleaner requestBodyCleaner;
-
-    @Autowired
     private Configuration configuration;
 
-    @SuppressWarnings("rawtypes")
     @RequestMapping(
             value = "services/collector",
             method = RequestMethod.POST,
@@ -83,23 +86,42 @@ public class HECRestController {
             produces = MediaType.APPLICATION_JSON_VALUE
     )
     public ResponseEntity<JsonNode> sendEvents(
-            HttpServletRequest request,
-            @RequestBody MultiValueMap body,
-            @RequestParam(required = false) String channel
+            final HttpServletRequest request,
+            @RequestBody final MultiValueMap<String, String> body,
+            @RequestParam(required = false) final String channel
     ) {
-        // TODO: Try to think an alternative way to implement getting the body of the
-        // call
-        final String eventInJson = requestBodyCleaner.cleanAckRequestBody(body.toString(), channel);
-
-        long t1 = System.nanoTime();
-        final Response response = service.sendEvents(request, channel, eventInJson);
-        long t2 = System.nanoTime();
-        long dt = t2 - t1;
-        double us = (double) dt / 1000.0;
-        if (this.configuration.getPrintTimes()) {
-            LOGGER.info("sendEvents took <{}> nanoseconds, that is <{}> microseconds", dt, us);
+        ResponseEntity<JsonNode> responseEntity;
+        try {
+            final MultiValueMapRequest eventInJson = new MultiValueMapRequest(body);
+            final long t1 = System.nanoTime();
+            final Response response = service.sendEvents(request, channel, eventInJson.asCleanedJsonString());
+            final long t2 = System.nanoTime();
+            final long dt = t2 - t1;
+            final double us = (double) dt / 1000.0;
+            if (this.configuration.getPrintTimes()) {
+                LOGGER.info("sendEvents took <{}> nanoseconds, that is <{}> microseconds", dt, us);
+            }
+            responseEntity = response.asJsonNodeResponseEntity();
         }
-        return response.asJsonNodeResponseEntity();
+        catch (final IllegalStateException illegalStateException) {
+            final HeaderInfo headerInfo = new HeaderInfo(request);
+            final ExceptionEventContext exceptionEventContext = new ExceptionEventContext(
+                    headerInfo,
+                    request.getHeader("user-agent"),
+                    request.getRequestURI(),
+                    request.getRemoteHost()
+            );
+            final ExceptionEvent event = new ExceptionEvent(
+                    exceptionEventContext,
+                    UUID.randomUUID(),
+                    illegalStateException
+            );
+            event.logException();
+            final Response response = new ExceptionJsonResponse(event);
+            responseEntity = response.asJsonNodeResponseEntity();
+        }
+
+        return responseEntity;
     }
 
     @RequestMapping(
@@ -132,25 +154,23 @@ public class HECRestController {
             },
             consumes = MediaType.APPLICATION_JSON_VALUE
     )
-    public JsonNode getAcksWithPostMethod(
+    public ResponseEntity<JsonNode> getAcksWithPostMethod(
             @RequestBody JsonNode requestedAcksInJson,
             HttpServletRequest request,
             @RequestParam(required = false) String channel
     ) {
 
         long t1 = System.nanoTime();
-        JsonNode response = service.getAcks(request, channel, requestedAcksInJson);
+        final Response response = service.getAcks(request, channel, requestedAcksInJson);
         long t2 = System.nanoTime();
         long dt = t2 - t1;
         double us = (double) dt / 1000.0;
         if (this.configuration.getPrintTimes()) {
             LOGGER.info("getAcks took <{}> nanoseconds, that is <{}> microseconds", dt, us);
         }
-        return response;
+        return response.asJsonNodeResponseEntity();
     }
 
-    // @LogAnnotation(type = LogType.METRIC_DURATION)
-    @SuppressWarnings("rawtypes")
     @RequestMapping(
             value = "services/collector/ack",
             method = {
@@ -158,53 +178,60 @@ public class HECRestController {
             },
             consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE
     )
-    public @ResponseBody JsonNode getAcks(
-            @RequestBody MultiValueMap body,
-            HttpServletRequest request,
-            @RequestParam(required = false) String channel
+    public ResponseEntity<JsonNode> getAcks(
+            @RequestBody final MultiValueMap<String, String> body,
+            final HttpServletRequest request,
+            @RequestParam(required = false) final String channel
     ) {
-        // TODO: Try to think an alternative way to implement getting the body of the
-        // call
-        String bodyString = requestBodyCleaner.cleanAckRequestBody(body.toString(), channel);
+        ResponseEntity<JsonNode> responseEntity;
 
-        JsonNode requestedAcksInJson = null;
         try {
-            requestedAcksInJson = objectMapper.readValue(bodyString, JsonNode.class);
+            final MultiValueMapRequest multiValueMapRequest = new MultiValueMapRequest(body);
+
+            final JsonNode requestedAcksInJson = objectMapper
+                    .readValue(multiValueMapRequest.asCleanedJsonString(), JsonNode.class);
+
+            final long t1 = System.nanoTime();
+            final Response response = service.getAcks(request, channel, requestedAcksInJson);
+            final long t2 = System.nanoTime();
+            final long dt = t2 - t1;
+            final double us = (double) dt / 1000.0;
+            if (this.configuration.getPrintTimes()) {
+                LOGGER.info("getAcks took <{}> nanoseconds, that is <{}> microseconds", dt, us);
+            }
+            responseEntity = new JsonResponse(response.toString()).asJsonNodeResponseEntity();
         }
-        catch (Exception e) {
-            // TODO: handle the error in a proper way
-            LOGGER.warn("Failed to handle response: ", e);
+        catch (final IllegalStateException | JacksonException exception) {
+            final HeaderInfo headerInfo = new HeaderInfo(request);
+            final ExceptionEventContext exceptionEventContext = new ExceptionEventContext(
+                    headerInfo,
+                    request.getHeader("user-agent"),
+                    request.getRequestURI(),
+                    request.getRemoteHost()
+            );
+            final ExceptionEvent event = new ExceptionEvent(exceptionEventContext, UUID.randomUUID(), exception);
+            event.logException();
+            final Response response = new ExceptionJsonResponse(event);
+            responseEntity = response.asJsonNodeResponseEntity();
         }
 
-        long t1 = System.nanoTime();
-        JsonNode response = service.getAcks(request, channel, requestedAcksInJson);
-        long t2 = System.nanoTime();
-        long dt = t2 - t1;
-        double us = (double) dt / 1000.0;
-        if (this.configuration.getPrintTimes()) {
-            LOGGER.info("getAcks took <{}> nanoseconds, that is <{}> microseconds", dt, us);
-        }
-        return response;
+        return responseEntity;
     }
 
-    @SuppressWarnings("rawtypes")
     @RequestMapping(
             value = "services/collector/event",
             method = RequestMethod.POST,
             consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE
     )
     public ResponseEntity<JsonNode> sendEventsWithFormatOption(
-            HttpServletRequest request,
-            @RequestBody MultiValueMap body,
-            @RequestParam(required = false) String channel
+            final HttpServletRequest request,
+            @RequestBody final MultiValueMap<String, String> body,
+            @RequestParam(required = false) final String channel
     ) {
-
-        // TODO: Try to think an alternative way to implement getting the body of the
-        // call
-        String eventInJson = requestBodyCleaner.cleanAckRequestBody(body.toString(), channel);
+        final MultiValueMapRequest multiValueMapRequest = new MultiValueMapRequest(body);
 
         long t1 = System.nanoTime();
-        final Response response = service.sendEvents(request, channel, eventInJson);
+        final Response response = service.sendEvents(request, channel, multiValueMapRequest.asCleanedJsonString());
         long t2 = System.nanoTime();
         long dt = t2 - t1;
         double us = (double) dt / 1000.0;

--- a/src/main/java/com/teragrep/cfe_16/service/HECService.java
+++ b/src/main/java/com/teragrep/cfe_16/service/HECService.java
@@ -71,7 +71,7 @@ public interface HECService {
      * @param requestedAcksInJson
      * @return
      */
-    public JsonNode getAcks(HttpServletRequest request, String channel, JsonNode requestedAcksInJson);
+    public Response getAcks(HttpServletRequest request, String channel, JsonNode requestedAcksInJson);
 
     /**
      * Ping.

--- a/src/main/java/com/teragrep/cfe_16/service/HECServiceImpl.java
+++ b/src/main/java/com/teragrep/cfe_16/service/HECServiceImpl.java
@@ -45,10 +45,10 @@
  */
 package com.teragrep.cfe_16.service;
 
+import com.teragrep.cfe_16.response.AcknowledgementResponse;
 import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.node.ObjectNode;
 import com.teragrep.cfe_16.*;
 import com.teragrep.cfe_16.bo.Ack;
 import com.teragrep.cfe_16.bo.HeaderInfo;
@@ -215,7 +215,11 @@ public class HECServiceImpl implements HECService {
 
     @SuppressWarnings("deprecation")
     @Override
-    public JsonNode getAcks(HttpServletRequest request, String channel, JsonNode requestedAcksInJson) {
+    public Response getAcks(
+            final HttpServletRequest request,
+            final String channel,
+            final JsonNode requestedAcksInJson
+    ) {
 
         // filter out error cases
         // authentication header is required always
@@ -252,11 +256,9 @@ public class HECServiceImpl implements HECService {
         }
         session.touch();
 
-        ObjectNode responseNode = objectMapper.createObjectNode();
-        JsonNode requestedAckStatuses = this.acknowledgements
+        final JsonNode requestedAckStatuses = this.acknowledgements
                 .getRequestedAckStatuses(authToken, channel, requestedAcksInJson);
-        responseNode.set("acks", requestedAckStatuses);
-        return responseNode;
+        return new AcknowledgementResponse(requestedAckStatuses);
     }
 
     @Override

--- a/src/test/java/com/teragrep/cfe_16/MultiValueMapRequestTest.java
+++ b/src/test/java/com/teragrep/cfe_16/MultiValueMapRequestTest.java
@@ -47,6 +47,7 @@ package com.teragrep.cfe_16;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -69,5 +70,46 @@ class MultiValueMapRequestTest {
                         "{\"sourcetype\": \"mysourcetype\", \"event\": \"Hello, world!\"}", cleaned,
                         "Did not clean channel properly"
                 );
+    }
+
+    @Test
+    @DisplayName("test MultiValueMapRequest without channel present")
+    void testMultiValueMapRequestWithoutChannelPresent() {
+        final MultiValueMap<String, String> multiValueMap = new LinkedMultiValueMap<>();
+        multiValueMap.add("{\"sourcetype\": \"mysourcetype\", \"event\": \"Hello, world!\"}", null);
+        final MultiValueMapRequest multiValueMapRequest = new MultiValueMapRequest(multiValueMap);
+
+        final String cleaned = multiValueMapRequest.asCleanedJsonString();
+        Assertions
+                .assertEquals(
+                        "{\"sourcetype\": \"mysourcetype\", \"event\": \"Hello, world!\"}", cleaned,
+                        "Did not clean channel properly"
+                );
+    }
+
+    @Test
+    @DisplayName("asCleanedJsonString with more than 2 keys")
+    void asCleanedJsonStringWithMoreThan2Keys() {
+        final MultiValueMap<String, String> multiValueMap = new LinkedMultiValueMap<>();
+        multiValueMap.add("channel", "CHANNEL_11111");
+        multiValueMap.add("somethingElse", "asdfg");
+        multiValueMap.add("{\"sourcetype\": \"mysourcetype\", \"event\": \"Hello, world!\"}", null);
+        final MultiValueMapRequest multiValueMapRequest = new MultiValueMapRequest(multiValueMap);
+
+        final IllegalStateException illegalStateException = assertThrowsExactly(
+                IllegalStateException.class, multiValueMapRequest::asCleanedJsonString
+        );
+
+        Assertions
+                .assertEquals(
+                        "application/x-www-form-urlencoded request contains more parameters than expected",
+                        illegalStateException.getMessage()
+                );
+    }
+
+    @Test
+    @DisplayName("equalsVerifier test")
+    void equalsVerifierTest() {
+        EqualsVerifier.forClass(MultiValueMapRequest.class).verify();
     }
 }

--- a/src/test/java/com/teragrep/cfe_16/MultiValueMapRequestTest.java
+++ b/src/test/java/com/teragrep/cfe_16/MultiValueMapRequestTest.java
@@ -1,0 +1,73 @@
+/*
+ * HTTP Event Capture to RFC5424 CFE_16
+ * Copyright (C) 2021-2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.cfe_16;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+class MultiValueMapRequestTest {
+
+    @Test
+    @DisplayName("test MultiValueMapRequest with channel present")
+    void testMultiValueMapRequestWithChannelPresent() {
+        final MultiValueMap<String, String> multiValueMap = new LinkedMultiValueMap<>();
+        multiValueMap.add("channel", "CHANNEL_11111");
+        multiValueMap.add("{\"sourcetype\": \"mysourcetype\", \"event\": \"Hello, world!\"}", null);
+        final MultiValueMapRequest multiValueMapRequest = new MultiValueMapRequest(multiValueMap);
+
+        final String cleaned = multiValueMapRequest.asCleanedJsonString();
+        Assertions
+                .assertEquals(
+                        "{\"sourcetype\": \"mysourcetype\", \"event\": \"Hello, world!\"}", cleaned,
+                        "Did not clean channel properly"
+                );
+    }
+}

--- a/src/test/java/com/teragrep/cfe_16/MultiValueMapRequestTest.java
+++ b/src/test/java/com/teragrep/cfe_16/MultiValueMapRequestTest.java
@@ -108,6 +108,29 @@ class MultiValueMapRequestTest {
     }
 
     @Test
+    @DisplayName("test that asCleanedJsonString does not modify multiValueMap field")
+    void testThatAsCleanedJsonStringDoesNotModifyMultiValueMapField() {
+        final MultiValueMap<String, String> multiValueMap = new LinkedMultiValueMap<>();
+        multiValueMap.add("channel", "CHANNEL_11111");
+        multiValueMap.add("{\"sourcetype\": \"mysourcetype\", \"event\": \"Hello, world!\"}", null);
+        final MultiValueMapRequest multiValueMapRequest = new MultiValueMapRequest(multiValueMap);
+
+        final String cleaned = multiValueMapRequest.asCleanedJsonString();
+        Assertions
+                .assertEquals(
+                        "{\"sourcetype\": \"mysourcetype\", \"event\": \"Hello, world!\"}", cleaned,
+                        "Did not clean channel properly"
+                );
+
+        final MultiValueMap<String, String> nonModifiedMultiValueMap = new LinkedMultiValueMap<>();
+        nonModifiedMultiValueMap.add("channel", "CHANNEL_11111");
+        nonModifiedMultiValueMap.add("{\"sourcetype\": \"mysourcetype\", \"event\": \"Hello, world!\"}", null);
+        final MultiValueMapRequest nonModifiedMultiValueMapRequest = new MultiValueMapRequest(nonModifiedMultiValueMap);
+
+        Assertions.assertEquals(nonModifiedMultiValueMapRequest, multiValueMapRequest);
+    }
+
+    @Test
     @DisplayName("equalsVerifier test")
     void equalsVerifierTest() {
         EqualsVerifier.forClass(MultiValueMapRequest.class).verify();

--- a/src/test/java/com/teragrep/cfe_16/it/ServiceAndHECBatchIT.java
+++ b/src/test/java/com/teragrep/cfe_16/it/ServiceAndHECBatchIT.java
@@ -45,6 +45,7 @@
  */
 package com.teragrep.cfe_16.it;
 
+import com.teragrep.cfe_16.response.AcknowledgementResponse;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import com.teragrep.cfe_16.exceptionhandling.*;
@@ -63,6 +64,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.junit.Assert.*;
 
@@ -205,8 +207,12 @@ public class ServiceAndHECBatchIT {
                         "Service should return JSON object with fields 'text', 'code' and 'ackID' (ackID should be 0)"
                 );
 
-        final String supposedResponse5 = "{\"acks\":{\"1\":true,\"3\":false,\"4\":false}}";
-        final String returnedResponse5 = service.getAcks(request1, channel3, ackRequestNode).toString();
+        final ObjectNode objectNode = objectMapper.createObjectNode();
+        objectNode.put("1", true);
+        objectNode.put("3", false);
+        objectNode.put("4", false);
+        final Response supposedResponse5 = new AcknowledgementResponse(objectNode);
+        final Response returnedResponse5 = service.getAcks(request1, channel3, ackRequestNode);
 
         Assertions
                 .assertEquals(supposedResponse5, returnedResponse5, "JSON object should be returned with ack statuses.");

--- a/src/test/java/com/teragrep/cfe_16/response/AcknowledgementResponseTest.java
+++ b/src/test/java/com/teragrep/cfe_16/response/AcknowledgementResponseTest.java
@@ -43,39 +43,44 @@
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
  */
-package com.teragrep.cfe_16;
+package com.teragrep.cfe_16.response;
 
-import org.springframework.stereotype.Component;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 
-import java.util.regex.Pattern;
+class AcknowledgementResponseTest {
 
-/*
- * Cleans the request body so, that only the body of the request is left in the string.
- * This is needed when calling the endpoint that consumes MediaType.APPLICATION_FORM_URLENCODED_VALUE
- * Example of body sent as a parameter: {channel=[CHANNEL_11111], {"sourcetype": "mysourcetype", "event": "Hello, world!"}=[]}
- * Example of cleaned body returned by the cleanAckRequestBody(): {"sourcetype": "mysourcetype", "event": "Hello, world!"}
- * TODO: Try to implement a better way to get the body of the request.
- *
- */
-@Component
-public class RequestBodyCleaner {
+    @Test
+    @DisplayName("test that asJsonNodeResponseEntity has acks key")
+    void testThatAsJsonNodeResponseEntityHasAcksKey() {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final ObjectNode objectNode = objectMapper.createObjectNode();
 
-    public String cleanAckRequestBody(String body, String channel) {
-        String bodyWithoutChannel = body.replaceAll("channel=\\[" + Pattern.quote(channel) + "\\]\\, ", "");
-        String bodywithoutChannelLastCharRemoved = removeLastChar(bodyWithoutChannel);
+        final AcknowledgementResponse acknowledgementResponse = new AcknowledgementResponse(objectNode);
+        final ResponseEntity<JsonNode> jsonNodeResponseEntity = acknowledgementResponse.asJsonNodeResponseEntity();
 
-        String cleanedBody = bodywithoutChannelLastCharRemoved.substring(1);
+        Assertions.assertTrue(jsonNodeResponseEntity.hasBody());
 
-        cleanedBody = removeEqualsArrayFromEnd(cleanedBody);
+        final ObjectNode expectedObjectNode = objectMapper.createObjectNode();
+        expectedObjectNode.set("acks", objectNode);
+        final ResponseEntity<JsonNode> expectedResponseEntity = ResponseEntity
+                .ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(expectedObjectNode);
 
-        return cleanedBody;
+        Assertions.assertEquals(expectedResponseEntity, jsonNodeResponseEntity);
     }
 
-    private String removeLastChar(String str) {
-        return str.substring(0, str.length() - 1);
-    }
-
-    private String removeEqualsArrayFromEnd(String str) {
-        return str.replace("=[]", "");
+    @Test
+    @DisplayName("equalsVerifier test")
+    void equalsVerifierTest() {
+        EqualsVerifier.forClass(AcknowledgementResponse.class).verify();
     }
 }

--- a/src/test/java/com/teragrep/cfe_16/rest/HECRestControllerTest.java
+++ b/src/test/java/com/teragrep/cfe_16/rest/HECRestControllerTest.java
@@ -123,12 +123,12 @@ class HECRestControllerTest {
                 + "{\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", \"event\": "
                 + "{\"message\":\"Access log test message 2\"}}";
 
-        final ResponseEntity<JsonNode> variable = Assertions
+        final ResponseEntity<JsonNode> responseEntity = Assertions
                 .assertDoesNotThrow(() -> this.hecRestController.sendEvents(request1, eventInJson, channel1));
         final AcknowledgedJsonResponse expectedResponse = new AcknowledgedJsonResponse("Success", 0);
-        final ResponseEntity<JsonNode> jsonNodeResponseEntity = expectedResponse.asJsonNodeResponseEntity();
+        final ResponseEntity<JsonNode> expectedResponseEntity = expectedResponse.asJsonNodeResponseEntity();
 
-        Assertions.assertEquals(jsonNodeResponseEntity, variable);
+        Assertions.assertEquals(expectedResponseEntity, responseEntity);
     }
 
     @Test
@@ -164,12 +164,12 @@ class HECRestControllerTest {
         multiValueMap.add("channel", channel1);
         multiValueMap.add(eventInJson, null);
 
-        final ResponseEntity<JsonNode> variable = Assertions
+        final ResponseEntity<JsonNode> responseEntity = Assertions
                 .assertDoesNotThrow(() -> this.hecRestController.sendEvents(request1, multiValueMap, channel1));
         final AcknowledgedJsonResponse expectedResponse = new AcknowledgedJsonResponse("Success", 0);
-        final ResponseEntity<JsonNode> jsonNodeResponseEntity = expectedResponse.asJsonNodeResponseEntity();
+        final ResponseEntity<JsonNode> expectedResponseEntity = expectedResponse.asJsonNodeResponseEntity();
 
-        Assertions.assertEquals(jsonNodeResponseEntity, variable);
+        Assertions.assertEquals(expectedResponseEntity, responseEntity);
     }
 
     @Test
@@ -185,11 +185,11 @@ class HECRestControllerTest {
         final MultiValueMap<String, String> multiValueMap = new LinkedMultiValueMap<>();
         multiValueMap.add(eventInJson, null);
 
-        final ResponseEntity<JsonNode> variable = Assertions
+        final ResponseEntity<JsonNode> responseEntity = Assertions
                 .assertDoesNotThrow(() -> this.hecRestController.sendEvents(request1, multiValueMap, null));
         final JsonResponse expectedResponse = new JsonResponse("Success");
-        final ResponseEntity<JsonNode> jsonNodeResponseEntity = expectedResponse.asJsonNodeResponseEntity();
+        final ResponseEntity<JsonNode> expectedResponseEntity = expectedResponse.asJsonNodeResponseEntity();
 
-        Assertions.assertEquals(jsonNodeResponseEntity, variable);
+        Assertions.assertEquals(expectedResponseEntity, responseEntity);
     }
 }

--- a/src/test/java/com/teragrep/cfe_16/rest/HECRestControllerTest.java
+++ b/src/test/java/com/teragrep/cfe_16/rest/HECRestControllerTest.java
@@ -187,7 +187,7 @@ class HECRestControllerTest {
 
         final ResponseEntity<JsonNode> variable = Assertions
                 .assertDoesNotThrow(() -> this.hecRestController.sendEvents(request1, multiValueMap, null));
-        final AcknowledgedJsonResponse expectedResponse = new AcknowledgedJsonResponse("Success", 0);
+        final JsonResponse expectedResponse = new JsonResponse("Success");
         final ResponseEntity<JsonNode> jsonNodeResponseEntity = expectedResponse.asJsonNodeResponseEntity();
 
         Assertions.assertEquals(jsonNodeResponseEntity, variable);

--- a/src/test/java/com/teragrep/cfe_16/rest/HECRestControllerTest.java
+++ b/src/test/java/com/teragrep/cfe_16/rest/HECRestControllerTest.java
@@ -141,12 +141,12 @@ class HECRestControllerTest {
                 + "{\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", \"event\": "
                 + "{\"message\":\"Access log test message 2\"}}";
 
-        final ResponseEntity<JsonNode> variable = Assertions
+        final ResponseEntity<JsonNode> responseEntity = Assertions
                 .assertDoesNotThrow(() -> this.hecRestController.sendEvents(request1, eventInJson, null));
         final JsonResponse expectedResponse = new JsonResponse("Success");
-        final ResponseEntity<JsonNode> jsonNodeResponseEntity = expectedResponse.asJsonNodeResponseEntity();
+        final ResponseEntity<JsonNode> expectedResponseEntity = expectedResponse.asJsonNodeResponseEntity();
 
-        Assertions.assertEquals(jsonNodeResponseEntity, variable);
+        Assertions.assertEquals(expectedResponseEntity, responseEntity);
     }
 
     @Test

--- a/src/test/java/com/teragrep/cfe_16/rest/HECRestControllerTest.java
+++ b/src/test/java/com/teragrep/cfe_16/rest/HECRestControllerTest.java
@@ -1,0 +1,195 @@
+/*
+ * HTTP Event Capture to RFC5424 CFE_16
+ * Copyright (C) 2021-2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.cfe_16.rest;
+
+import com.teragrep.cfe_16.response.AcknowledgedJsonResponse;
+import com.teragrep.cfe_16.response.JsonResponse;
+import com.teragrep.cfe_16.server.TestServer;
+import com.teragrep.cfe_16.server.TestServerFactory;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import tools.jackson.databind.JsonNode;
+
+@TestPropertySource(properties = {
+        "syslog.server.host=127.0.0.1",
+        "syslog.server.port=1248",
+        "syslog.server.protocol=RELP",
+        "max.channels=1000000",
+        "max.ack.value=1000000",
+        "max.ack.age=20000",
+        "max.session.age=30000",
+        "poll.time=30000",
+        "spring.devtools.add-properties=false",
+        "server.print.times=true"
+})
+@SpringBootTest
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+class HECRestControllerTest {
+
+    private static final int SERVER_PORT = 1248;
+    private static final ConcurrentLinkedDeque<byte[]> messageList = new ConcurrentLinkedDeque<>();
+    private static final AtomicLong openCount = new AtomicLong();
+    private static final AtomicLong closeCount = new AtomicLong();
+    private static TestServer server;
+    @Autowired
+    private HECRestController hecRestController;
+
+    @BeforeAll
+    static void init() {
+        final TestServerFactory serverFactory = new TestServerFactory();
+        server = Assertions
+                .assertDoesNotThrow(() -> serverFactory.create(SERVER_PORT, messageList, openCount, closeCount));
+        server.run();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        Assertions.assertDoesNotThrow(() -> server.close());
+    }
+
+    @AfterEach
+    void clear() {
+        openCount.set(0);
+        closeCount.set(0);
+        messageList.clear();
+    }
+
+    @Test
+    @DisplayName("test JSON sendEvents endpoint with channel present")
+    void testJsonSendEventsEndpointWithChannelPresent() {
+        final MockHttpServletRequest request1 = new MockHttpServletRequest();
+        request1.addHeader("Authorization", "AUTH_TOKEN_11111");
+        final String channel1 = "CHANNEL_11111";
+        final String eventInJson = "{\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", "
+                + "\"event\": {\"message\":\"Access log test message 1\"}} "
+                + "{\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", \"event\": "
+                + "{\"message\":\"Access log test message 2\"}}";
+
+        final ResponseEntity<JsonNode> variable = Assertions
+                .assertDoesNotThrow(() -> this.hecRestController.sendEvents(request1, eventInJson, channel1));
+        final AcknowledgedJsonResponse expectedResponse = new AcknowledgedJsonResponse("Success", 0);
+        final ResponseEntity<JsonNode> jsonNodeResponseEntity = expectedResponse.asJsonNodeResponseEntity();
+
+        Assertions.assertEquals(jsonNodeResponseEntity, variable);
+    }
+
+    @Test
+    @DisplayName("test JSON sendEvents endpoint without channel present")
+    void testJsonSendEventsEndpointWithoutChannelPresent() {
+        final MockHttpServletRequest request1 = new MockHttpServletRequest();
+        request1.addHeader("Authorization", "AUTH_TOKEN_11111");
+        final String eventInJson = "{\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", "
+                + "\"event\": {\"message\":\"Access log test message 1\"}} "
+                + "{\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", \"event\": "
+                + "{\"message\":\"Access log test message 2\"}}";
+
+        final ResponseEntity<JsonNode> variable = Assertions
+                .assertDoesNotThrow(() -> this.hecRestController.sendEvents(request1, eventInJson, null));
+        final JsonResponse expectedResponse = new JsonResponse("Success");
+        final ResponseEntity<JsonNode> jsonNodeResponseEntity = expectedResponse.asJsonNodeResponseEntity();
+
+        Assertions.assertEquals(jsonNodeResponseEntity, variable);
+    }
+
+    @Test
+    @DisplayName("test multiValueMap sendEvents endpoint with channel present")
+    void testMultiValueMapSendEventsEndpointWithChannelPresent() {
+        final MockHttpServletRequest request1 = new MockHttpServletRequest();
+        request1.addHeader("Authorization", "AUTH_TOKEN_11111");
+        final String channel1 = "CHANNEL_11111";
+        // Send JSON without the outer object brackets
+        final String eventInJson = "\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", "
+                + "\"event\": {\"message\":\"Access log test message 1\"}} "
+                + "{\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", \"event\": "
+                + "{\"message\":\"Access log test message 2\"}";
+        final MultiValueMap<String, String> multiValueMap = new LinkedMultiValueMap<>();
+        multiValueMap.add("channel", channel1);
+        multiValueMap.add(eventInJson, null);
+
+        final ResponseEntity<JsonNode> variable = Assertions
+                .assertDoesNotThrow(() -> this.hecRestController.sendEvents(request1, multiValueMap, channel1));
+        final AcknowledgedJsonResponse expectedResponse = new AcknowledgedJsonResponse("Success", 0);
+        final ResponseEntity<JsonNode> jsonNodeResponseEntity = expectedResponse.asJsonNodeResponseEntity();
+
+        Assertions.assertEquals(jsonNodeResponseEntity, variable);
+    }
+
+    @Test
+    @DisplayName("test multiValueMap sendEvents endpoint without channel present")
+    void testMultiValueMapSendEventsEndpointWithoutChannelPresent() {
+        final MockHttpServletRequest request1 = new MockHttpServletRequest();
+        request1.addHeader("Authorization", "AUTH_TOKEN_11111");
+        // Send JSON without the outer object brackets
+        final String eventInJson = "\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", "
+                + "\"event\": {\"message\":\"Access log test message 1\"}} "
+                + "{\"sourcetype\":\"access\", \"source\":\"/var/log/access.log\", \"event\": "
+                + "{\"message\":\"Access log test message 2\"}";
+        final MultiValueMap<String, String> multiValueMap = new LinkedMultiValueMap<>();
+        multiValueMap.add(eventInJson, null);
+
+        final ResponseEntity<JsonNode> variable = Assertions
+                .assertDoesNotThrow(() -> this.hecRestController.sendEvents(request1, multiValueMap, null));
+        final AcknowledgedJsonResponse expectedResponse = new AcknowledgedJsonResponse("Success", 0);
+        final ResponseEntity<JsonNode> jsonNodeResponseEntity = expectedResponse.asJsonNodeResponseEntity();
+
+        Assertions.assertEquals(jsonNodeResponseEntity, variable);
+    }
+}

--- a/src/test/resources/cfe-16-test-plan.jmx
+++ b/src/test/resources/cfe-16-test-plan.jmx
@@ -5,22 +5,9 @@
       <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
         <collectionProp name="Arguments.arguments"/>
       </elementProp>
-      <boolProp name="TestPlan.functional_mode">false</boolProp>
-      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
     </TestPlan>
     <hashTree>
-      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
-        <collectionProp name="Arguments.arguments">
-          <elementProp name="host" elementType="Argument">
-            <stringProp name="Argument.name">host</stringProp>
-            <stringProp name="Argument.value">wsf.cdyne.com</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-            <stringProp name="Argument.desc">Host of Webservice</stringProp>
-          </elementProp>
-        </collectionProp>
-      </Arguments>
-      <hashTree/>
-      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Number of Users" enabled="true">
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Number of Users">
         <intProp name="ThreadGroup.num_threads">8</intProp>
         <intProp name="ThreadGroup.ramp_time">0</intProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
@@ -31,7 +18,7 @@
         </elementProp>
       </ThreadGroup>
       <hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Soap Request" enabled="true">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Soap Request">
           <stringProp name="HTTPSampler.domain">127.0.0.1</stringProp>
           <stringProp name="HTTPSampler.port">8080</stringProp>
           <stringProp name="HTTPSampler.protocol">http</stringProp>
@@ -139,7 +126,7 @@
           </JSONPathAssertion>
           <hashTree/>
         </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Soap Request" enabled="true">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Soap Request">
           <stringProp name="HTTPSampler.domain">127.0.0.1</stringProp>
           <stringProp name="HTTPSampler.port">8080</stringProp>
           <stringProp name="HTTPSampler.protocol">http</stringProp>
@@ -193,7 +180,7 @@
           </JSONPathAssertion>
           <hashTree/>
         </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Soap Request" enabled="true">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Soap Request">
           <stringProp name="HTTPSampler.domain">127.0.0.1</stringProp>
           <stringProp name="HTTPSampler.port">8080</stringProp>
           <stringProp name="HTTPSampler.protocol">http</stringProp>
@@ -247,7 +234,7 @@
           </JSONPathAssertion>
           <hashTree/>
         </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Soap Request" enabled="true">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Soap Request">
           <stringProp name="HTTPSampler.domain">127.0.0.1</stringProp>
           <stringProp name="HTTPSampler.port">8080</stringProp>
           <stringProp name="HTTPSampler.protocol">http</stringProp>
@@ -301,7 +288,7 @@
           </JSONPathAssertion>
           <hashTree/>
         </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Soap Request with message node" enabled="true">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Soap Request with message node">
           <stringProp name="HTTPSampler.domain">127.0.0.1</stringProp>
           <stringProp name="HTTPSampler.port">8080</stringProp>
           <stringProp name="HTTPSampler.protocol">http</stringProp>
@@ -335,7 +322,7 @@
             </collectionProp>
           </HeaderManager>
           <hashTree/>
-          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response is success" enabled="true">
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response is success">
             <collectionProp name="Asserion.test_strings">
               <stringProp name="49586">200</stringProp>
             </collectionProp>
@@ -345,7 +332,7 @@
             <intProp name="Assertion.test_type">8</intProp>
           </ResponseAssertion>
           <hashTree/>
-          <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="JSON Assertion" enabled="true">
+          <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="JSON Assertion">
             <stringProp name="JSON_PATH">$.message</stringProp>
             <stringProp name="EXPECTED_VALUE">Success</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
@@ -355,7 +342,7 @@
           </JSONPathAssertion>
           <hashTree/>
         </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Failed Soap request" enabled="true">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Failed Soap request">
           <stringProp name="TestPlan.comments">Should trigger a JsonSyntaxException</stringProp>
           <stringProp name="HTTPSampler.domain">127.0.0.1</stringProp>
           <stringProp name="HTTPSampler.port">8080</stringProp>
@@ -488,7 +475,7 @@
             <intProp name="Assertion.test_type">8</intProp>
           </ResponseAssertion>
           <hashTree/>
-          <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="JSON Assertion - message field">
+          <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="JSON Assertion - message field" enabled="true">
             <stringProp name="JSON_PATH">$.message</stringProp>
             <stringProp name="EXPECTED_VALUE">An error occurred while processing your Request. See event id in the technical log for details.</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
@@ -497,10 +484,76 @@
             <boolProp name="ISREGEX">false</boolProp>
           </JSONPathAssertion>
           <hashTree/>
-          <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="JSON Assertion - id field is found">
+          <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="JSON Assertion - id field is found" enabled="true">
             <stringProp name="JSON_PATH">$.id</stringProp>
             <stringProp name="EXPECTED_VALUE"></stringProp>
             <boolProp name="JSONVALIDATION">false</boolProp>
+            <boolProp name="EXPECT_NULL">false</boolProp>
+            <boolProp name="INVERT">false</boolProp>
+            <boolProp name="ISREGEX">false</boolProp>
+          </JSONPathAssertion>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Soap Request with urlencoding">
+          <stringProp name="HTTPSampler.domain">127.0.0.1</stringProp>
+          <stringProp name="HTTPSampler.port">8080</stringProp>
+          <stringProp name="HTTPSampler.protocol">http</stringProp>
+          <stringProp name="HTTPSampler.path">/services/collector</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{&quot;sourcetype&quot;: &quot;mysourcetype&quot;, &quot;event&quot;: &quot;Hello, world!&quot;}&#xd;
+</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">Authorization</stringProp>
+                <stringProp name="Header.value">AUTH_TOKEN_11111</stringProp>
+              </elementProp>
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">Content-Type</stringProp>
+                <stringProp name="Header.value">application/x-www-form-urlencoded; charset=utf-8</stringProp>
+              </elementProp>
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">X-Forwarded-For</stringProp>
+                <stringProp name="Header.value">Jmeter-For</stringProp>
+              </elementProp>
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">X-Forwarded-Proto</stringProp>
+                <stringProp name="Header.value">Jmeter-Proto</stringProp>
+              </elementProp>
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">X-Forwarded-Host</stringProp>
+                <stringProp name="Header.value">Jmeter-Host</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response is success">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="49586">200</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.custom_message"></stringProp>
+            <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
+            <boolProp name="Assertion.assume_success">true</boolProp>
+            <intProp name="Assertion.test_type">8</intProp>
+          </ResponseAssertion>
+          <hashTree/>
+          <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="JSON Assertion">
+            <stringProp name="JSON_PATH">$.message</stringProp>
+            <stringProp name="EXPECTED_VALUE">Success</stringProp>
+            <boolProp name="JSONVALIDATION">true</boolProp>
             <boolProp name="EXPECT_NULL">false</boolProp>
             <boolProp name="INVERT">false</boolProp>
             <boolProp name="ISREGEX">false</boolProp>
@@ -542,7 +595,7 @@
             </value>
           </objProp>
           <stringProp name="filename"></stringProp>
-          <stringProp name="TestPlan.comments">Total samples should be 8 (threads) * 2000 (loops) * 8 (tests) = 128000</stringProp>
+          <stringProp name="TestPlan.comments">Total samples should be 8 (threads) * 2000 (loops) * 9 (tests) = 144000</stringProp>
         </ResultCollector>
         <hashTree/>
       </hashTree>


### PR DESCRIPTION
## Description
Closes #62 
<!-- Please include a summary of changes made in your pull request. -->
- Standardizes MultiValueMap endpoints with the same behavior as JSON endpoints
  - Does not require channel to be present when sending events to MultiValueMap endpoints
- Implements `AcknowledgementResponse` for responses involving acknowledgement
- Adds Apache JMeter test for the `application/x-www-form-urlencoded` sendEvents endpoint
<!-- If you can't fill all check boxes in Checklists section, please explain why. -->

## Checklists

<!-- Fill check boxes before submitting the pull request. -->

### Testing

#### General

- [x] I have checked that my test files and functions have meaningful names.
- [x] I have checked that each test tests only a single behavior.
- [x] I have done happy tests.
- [x] I have tested only my own code.
- [x] I have tested at least all public methods.

#### Assertions

- [x] I have checked that my tests use assertions and not runtime overhead.
- [x] I have checked that my tests end in assertions.
- [x] I have checked that there is no comparison statements in assertions.
- [x] I have checked that assertions are in tests and not in helper functions.
- [x] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [x] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [x] I have tested algorithms and anything else with the possibility of unbound growth.
- [x] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [x] I have checked that all test files are standalone.
- [x] I have checked that all test-specific fake objects and classes are in the test directory.
- [x] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [x] I have checked that my tests do not contain non-generic information.
- [x] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [x] I have checked that my tests do not use throws for exceptions.
- [x] I have checked that my tests do not use try-catch statements.
- [x] I have checked that my tests do not use if-else statements.

#### Java

- [x] I have checked that my tests for Java uses JUnit library.
- [x] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [x] I have only tested public behavior and not private implementation details.
- [x] I have checked that my tests are not (partially) commented out.
- [x] I have checked that hand-crafted variables in assertions are used accordingly.
- [x] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29).
- [x] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [x] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Object Quality.
- [x] I have checked that my code does not have any NULL values.
- [x] I have checked my code does not contain FIXME or TODO comments.
